### PR TITLE
Add Skywater PDK

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -12,14 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-# The structure for adding a third_party dependency is to create a folder in this
-# directory that will contain the build rules and workspace rules required to import
-# it.
-load("//dependency_support/at_clifford_yosys:at_clifford_yosys.bzl", "at_clifford_yosys")
-load("//dependency_support/com_google_skywater_pdk:com_google_skywater_pdk.bzl", "com_google_skywater_pdk")
-
-
-def dependency_support():
-  at_clifford_yosys()
-  com_google_skywater_pdk()
+# Empty BUILD file, just to make this directory a Bazel package.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,6 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+workspace(name = "com_google_bazel_rules_hdl")
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+
+maybe(
+    http_archive,
+    name = "rules_python",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.1.0/rules_python-0.1.0.tar.gz",
+    sha256 = "b6d46438523a3ec0f3cead544190ee13223a52f6a6765a29eae7b7cc24cc83a0",
+)
+load("//:init.bzl", "init")
+init()
 
 # Third Party
 load("//dependency_support:dependency_support.bzl", "dependency_support")

--- a/dependency_support/com_google_skywater_pdk/BUILD
+++ b/dependency_support/com_google_skywater_pdk/BUILD
@@ -12,14 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+licenses(["notice"])
 
-# The structure for adding a third_party dependency is to create a folder in this
-# directory that will contain the build rules and workspace rules required to import
-# it.
-load("//dependency_support/at_clifford_yosys:at_clifford_yosys.bzl", "at_clifford_yosys")
-load("//dependency_support/com_google_skywater_pdk:com_google_skywater_pdk.bzl", "com_google_skywater_pdk")
-
-
-def dependency_support():
-  at_clifford_yosys()
-  com_google_skywater_pdk()
+exports_files([
+    "liberty_wrapper.py",
+])

--- a/dependency_support/com_google_skywater_pdk/bundled.BUILD.bazel
+++ b/dependency_support/com_google_skywater_pdk/bundled.BUILD.bazel
@@ -1,0 +1,48 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+licenses(["notice"])
+
+load("@com_google_bazel_rules_hdl//dependency_support/com_google_skywater_pdk:cell_libraries.bzl", "CELL_LIBRARIES")
+load("@com_google_bazel_rules_hdl_pip_deps//:requirements.bzl", "requirement")
+
+py_binary(
+    name = "liberty",
+    visibility = ["//visibility:public"],
+    srcs = ["@com_google_bazel_rules_hdl//dependency_support/com_google_skywater_pdk:liberty_wrapper.py"],
+    main = "@com_google_bazel_rules_hdl//dependency_support/com_google_skywater_pdk:liberty_wrapper.py",
+    python_version = "PY3",
+    deps = [
+        ":skywater_pdk_py",
+    ],
+)
+
+py_library(
+    name = "skywater_pdk_py",
+    visibility = ["//visibility:public"],
+    srcs = glob(["scripts/python-skywater-pdk/skywater_pdk/*.py"]),
+    imports = ["scripts/python-skywater-pdk"],
+    deps = [
+        # The code only directly depends on dataclasses-json. I don't understand
+        # why the Bazel Python rules don't automatically depend on its
+        # dependencies.
+        requirement("dataclasses-json"),
+    ],
+)
+
+filegroup(
+    name = "timing_all",
+    visibility = ["//visibility:public"],
+    srcs = ["@com_google_skywater_pdk_%s//:timing_all" % library_name for library_name in CELL_LIBRARIES],
+)

--- a/dependency_support/com_google_skywater_pdk/cell_libraries.bzl
+++ b/dependency_support/com_google_skywater_pdk/cell_libraries.bzl
@@ -1,0 +1,228 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Has metadata about the cell libraries in the PDK.
+
+This is used by the Bazel rules to set up the proper workspaces and targets."""
+
+# The following is a list of cell libraries in the PDK. Each cell library has the
+# git commit to use and a list of process corners.
+#
+# This list is manually curated and needs to be updated when upgrading to newer
+# cell library versions.
+CELL_LIBRARIES = {
+    "sky130_fd_io": {
+        "commit": "7ec511f1a4689e174c63b3964d1ba8da9a3565e5",  # v0.2.1, 2020-12-09
+        "shallow_since": "1606239275 -0800",
+    },
+    "sky130_fd_pr": {
+        "commit": "f62031a1be9aefe902d6d54cddd6f59b57627436",  # v0.20.1, 2020-12-09
+        "shallow_since": "1605038979 -0800",
+    },
+    "sky130_fd_sc_hd": {
+        "commit": "ac7fb61f06e6470b94e8afdf7c25268f62fbd7b1",  # v0.0.2, 2020-12-04
+        "shallow_since": "1605028103 -0800",
+        "corners": {
+            "ff_100C_1v65": ["basic"],
+            "ff_100C_1v95": ["basic"],
+            "ff_n40C_1v56": ["basic"],
+            "ff_n40C_1v65": ["basic"],
+            "ff_n40C_1v76": ["basic"],
+            "ff_n40C_1v95": ["basic", "ccsnoise"],
+            "ss_100C_1v40": ["basic"],
+            "ss_100C_1v60": ["basic"],
+            "ss_n40C_1v28": ["basic"],
+            "ss_n40C_1v35": ["basic"],
+            "ss_n40C_1v40": ["basic"],
+            "ss_n40C_1v44": ["basic"],
+            "ss_n40C_1v60": ["basic", "ccsnoise"],
+            "ss_n40C_1v76": ["basic"],
+            "tt_025C_1v80": ["basic"],
+            "tt_100C_1v80": ["basic"],
+        },
+    },
+    "sky130_fd_sc_hdll": {
+        "commit": "0694bd23893de20f5233ef024acf6cca1e750ac6",  # v0.1.1, 2020-12-04
+        "shallow_since": "1604475910 -0800",
+        "corners": {
+            "ff_100C_1v65": ["basic"],
+            "ff_100C_1v95": ["basic"],
+            "ff_n40C_1v56": ["basic"],
+            "ff_n40C_1v65": ["basic"],
+            "ff_n40C_1v95": ["basic", "ccsnoise"],
+            "ss_100C_1v60": ["basic"],
+            "ss_n40C_1v28": ["basic"],
+            "ss_n40C_1v44": ["basic"],
+            "ss_n40C_1v60": ["basic", "ccsnoise"],
+            "ss_n40C_1v76": ["basic"],
+            "tt_025C_1v80": ["basic"],
+        },
+    },
+    "sky130_fd_sc_hs": {
+        "commit": "1d051f49bfe4e2fe9108d702a8bc2e9c081005a4",  # v0.0.2, 2020-12-04
+        "shallow_since": "1605574092 -0800",
+        "corners": {
+            "ff_100C_1v95": ["basic"],
+            "ff_150C_1v95": ["basic"],
+            "ff_n40C_1v56": ["basic"],
+            "ff_n40C_1v76": ["basic"],
+            "ff_n40C_1v95": ["basic", "ccsnoise"],
+            "ss_100C_1v60": ["basic"],
+            "ss_150C_1v60": ["basic"],
+            "ss_n40C_1v28": ["basic"],
+            "ss_n40C_1v44": ["basic"],
+            "ss_n40C_1v60": ["basic", "ccsnoise"],
+            "tt_025C_1v20": ["basic"],
+            "tt_025C_1v35": ["basic"],
+            "tt_025C_1v44": ["basic"],
+            "tt_025C_1v50": ["basic"],
+            "tt_025C_1v62": ["basic"],
+            "tt_025C_1v68": ["basic"],
+            "tt_025C_1v80": ["basic", "ccsnoise"],
+            "tt_025C_1v89": ["basic"],
+            "tt_025C_2v10": ["basic"],
+            "tt_100C_1v80": ["basic"],
+            "tt_150C_1v80": ["basic"],
+        },
+    },
+    "sky130_fd_sc_hvl": {
+        "commit": "4fd4f858d16c558a6a488b200649e909bb4dd800",  # v0.0.3, 2020-12-04
+        "shallow_since": "1604476031 -0800",
+        "corners": {
+            "ff_085C_5v50": ["basic"],
+            "ff_085C_5v50_lv1v95": ["basic"],
+            "ff_100C_5v50": ["basic"],
+            "ff_100C_5v50_lowhv1v65_lv1v95": ["basic"],
+            "ff_100C_5v50_lv1v95": ["basic"],
+            "ff_150C_5v50": ["basic"],
+            "ff_150C_5v50_lv1v95": ["basic"],
+            "ff_n40C_4v40": ["basic"],
+            "ff_n40C_4v40_lv1v95": ["basic"],
+            "ff_n40C_4v95": ["basic"],
+            "ff_n40C_4v95_lv1v95": ["basic"],
+            "ff_n40C_5v50": ["basic", "ccsnoise"],
+            "ff_n40C_5v50_lowhv1v65_lv1v95": ["basic"],
+            "ff_n40C_5v50_lv1v95": ["basic", "ccsnoise"],
+            "hvff_lvss_100C_5v50_lowhv1v65_lv1v60": ["basic"],
+            "hvff_lvss_100C_5v50_lv1v40": ["basic"],
+            "hvff_lvss_100C_5v50_lv1v60": ["basic"],
+            "hvff_lvss_n40C_5v50_lowhv1v65_lv1v60": ["basic"],
+            "hvff_lvss_n40C_5v50_lv1v35": ["basic"],
+            "hvff_lvss_n40C_5v50_lv1v60": ["basic"],
+            "hvss_lvff_100C_1v65": ["basic"],
+            "hvss_lvff_100C_1v95": ["basic"],
+            "hvss_lvff_100C_1v95_lowhv1v65": ["basic"],
+            "hvss_lvff_100C_5v50_lowhv1v65_lv1v95": ["basic"],
+            "hvss_lvff_n40C_1v65": ["basic"],
+            "hvss_lvff_n40C_1v95": ["basic"],
+            "hvss_lvff_n40C_1v95_lowhv1v65": ["basic"],
+            "hvss_lvff_n40C_5v50_lowhv1v65_lv1v95": ["basic"],
+            "ss_100C_1v65": ["basic"],
+            "ss_100C_1v65_lv1v40": ["basic"],
+            "ss_100C_1v65_lv1v60": ["basic"],
+            "ss_100C_1v95": ["basic"],
+            "ss_100C_2v40_lowhv1v65_lv1v60": ["basic"],
+            "ss_100C_2v70_lowhv1v65_lv1v60": ["basic"],
+            "ss_100C_3v00": ["basic"],
+            "ss_100C_3v00_lowhv1v65_lv1v60": ["basic"],
+            "ss_100C_5v50_lowhv1v65_lv1v60": ["basic"],
+            "ss_150C_1v65": ["basic"],
+            "ss_150C_1v65_lv1v60": ["basic"],
+            "ss_150C_3v00_lowhv1v65_lv1v60": ["basic"],
+            "ss_n40C_1v32": ["basic"],
+            "ss_n40C_1v32_lv1v28": ["basic"],
+            "ss_n40C_1v49": ["basic"],
+            "ss_n40C_1v49_lv1v44": ["basic"],
+            "ss_n40C_1v65": ["basic", "ccsnoise"],
+            "ss_n40C_1v65_lv1v35": ["basic"],
+            "ss_n40C_1v65_lv1v40": ["basic"],
+            "ss_n40C_1v65_lv1v60": ["basic", "ccsnoise"],
+            "ss_n40C_1v95": ["basic"],
+            "ss_n40C_5v50_lowhv1v65_lv1v60": ["basic"],
+            "tt_025C_2v64_lv1v80": ["basic"],
+            "tt_025C_2v97_lv1v80": ["basic"],
+            "tt_025C_3v30": ["basic"],
+            "tt_025C_3v30_lv1v80": ["basic"],
+            "tt_100C_3v30": ["basic"],
+            "tt_100C_3v30_lv1v80": ["basic"],
+            "tt_150C_3v30_lv1v80": ["basic"],
+        },
+    },
+    "sky130_fd_sc_lp": {
+        "commit": "e2c1e0646999163d35ea7b2521c3ec5c28633e63",  # v0.0.2, 2020-12-04
+        "shallow_since": "1604476084 -0800",
+        "corners": {
+            "ff_100C_1v95": ["basic"],
+            "ff_125C_3v15": ["basic"],
+            "ff_140C_1v95": ["basic"],
+            "ff_150C_2v05": ["basic"],
+            "ff_n40C_1v56": ["basic"],
+            "ff_n40C_1v76": ["basic"],
+            "ff_n40C_1v95": ["basic"],
+            "ff_n40C_2v05": ["basic"],
+            "ss_100C_1v60": ["basic"],
+            "ss_140C_1v65": ["basic"],
+            "ss_150C_1v65": ["basic"],
+            "ss_n40C_1v55": ["basic"],
+            "ss_n40C_1v60": ["basic"],
+            "ss_n40C_1v65": ["basic"],
+        },
+    },
+    "sky130_fd_sc_ls": {
+        "commit": "4f549e30dd91a1c264f8895e07b2872fe410a8c2",  # v0.1.1, 2020-12-04
+        "shallow_since": "1604476021 -0800",
+        "corners": {
+            "ff_085C_1v95": ["basic"],
+            "ff_100C_1v65_dest1v76_destvpb1v76_ka1v76": ["basic"],
+            "ff_100C_1v95": ["basic"],
+            "ff_150C_1v95": ["basic"],
+            "ff_n40C_1v56": ["basic"],
+            "ff_n40C_1v65_dest1v76_destvpb1v76_ka1v76": ["basic"],
+            "ff_n40C_1v76": ["basic"],
+            "ff_n40C_1v95": ["basic", "ccsnoise"],
+            "ss_100C_1v40": ["basic"],
+            "ss_100C_1v60": ["basic"],
+            "ss_150C_1v60": ["basic"],
+            "ss_n40C_1v28": ["basic"],
+            "ss_n40C_1v35": ["basic"],
+            "ss_n40C_1v40": ["basic"],
+            "ss_n40C_1v44": ["basic"],
+            "ss_n40C_1v60": ["basic", "ccsnoise"],
+            "ss_n40C_1v76": ["basic"],
+            "tt_025C_1v80": ["basic", "ccsnoise"],
+            "tt_100C_1v80": ["basic"],
+        },
+    },
+    "sky130_fd_sc_ms": {
+        "commit": "ae1b7f68821505cf2d93d9d44cce5ece22710fad",  # v0.0.2, 2020-12-04
+        "shallow_since": "1605631186 -0800",
+        "corners": {
+            "ff_085C_1v95": ["leakage"],
+            "ff_100C_1v65": ["basic"],
+            "ff_100C_1v95": ["basic", "leakage"],
+            "ff_150C_1v95": ["basic"],
+            "ff_n40C_1v56": ["basic"],
+            "ff_n40C_1v65_ka1v76": ["basic"],
+            "ff_n40C_1v76": ["basic"],
+            "ff_n40C_1v95": ["basic", "ccsnoise", "leakage"],
+            "ss_100C_1v60": ["basic"],
+            "ss_150C_1v60": ["basic"],
+            "ss_n40C_1v28": ["basic"],
+            "ss_n40C_1v44": ["basic"],
+            "ss_n40C_1v60": ["basic", "ccsnoise"],
+            "tt_025C_1v80": ["basic", "ccsnoise"],
+            "tt_100C_1v80": ["basic"],
+        },
+    },
+}

--- a/dependency_support/com_google_skywater_pdk/com_google_skywater_pdk.bzl
+++ b/dependency_support/com_google_skywater_pdk/com_google_skywater_pdk.bzl
@@ -1,0 +1,50 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Loads the Skywater open source process design kit."""
+
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load(":cell_libraries.bzl", "CELL_LIBRARIES")
+
+def _build_file(library_name):
+    library = CELL_LIBRARIES[library_name]
+    return """
+load("@com_google_bazel_rules_hdl//dependency_support/com_google_skywater_pdk:declare_cell_library.bzl", "declare_cell_library")
+declare_cell_library("%s")
+""" % library_name
+
+def com_google_skywater_pdk():
+    maybe(
+        http_archive,
+        name = "com_google_skywater_pdk",
+        urls = [
+            "https://github.com/google/skywater-pdk/archive/3d7617a1acb92ea883539bcf22a632d6361a5de4.tar.gz",  # 2020-12-04
+        ],
+        strip_prefix = "skywater-pdk-3d7617a1acb92ea883539bcf22a632d6361a5de4",
+        sha256 = "49e5b03c26131a03eb038697d396a6ebf14058d78196f5d95c2bbdb0bdc8f32e",
+        build_file = Label("//dependency_support/com_google_skywater_pdk:bundled.BUILD.bazel"),
+    )
+
+    for library_name in CELL_LIBRARIES:
+        library = CELL_LIBRARIES[library_name]
+        maybe(
+            new_git_repository,
+            name = "com_google_skywater_pdk_" + library_name,
+            commit = library["commit"],
+            remote = "https://foss-eda-tools.googlesource.com/skywater-pdk/libs/%s.git" % library_name,
+            shallow_since = library["shallow_since"],
+            build_file_content = _build_file(library_name),
+        )

--- a/dependency_support/com_google_skywater_pdk/declare_cell_library.bzl
+++ b/dependency_support/com_google_skywater_pdk/declare_cell_library.bzl
@@ -1,0 +1,66 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Internal helper function that is used by the BUILD files for each
+cell library workspace to set things up."""
+
+load(":cell_libraries.bzl", "CELL_LIBRARIES")
+
+_FILE_SUFFIX_BY_CORNER_TYPE = {
+    "basic": "",
+    "ccsnoise": "_ccsnoise",
+    "leakage": "_pwrlkg",
+}
+
+_GENERATOR_ARGUMENT_BY_CORNER_TYPE = {
+    "basic": "",
+    "ccsnoise": "--ccsnoise",
+    "leakage": "--leakage",
+}
+
+def declare_cell_library(library_name):
+    """This should be called from the BUILD file of a cell library
+    workspace. It sets up the targets for the generated files of
+    the given library."""
+    native.exports_files(native.glob(["**/*"]))
+    native.filegroup(
+        name = "spice_models",
+        srcs = native.glob(["**/*.spice"]),
+        visibility = ["//visibility:public"],
+    )
+    library = CELL_LIBRARIES[library_name]
+    corners = library.get("corners", {})
+    for corner in corners:
+        corner_types = library["corners"][corner]
+        for corner_type in corner_types:
+            out_path = "timing/%s__%s%s.lib" % (library_name, corner, _FILE_SUFFIX_BY_CORNER_TYPE[corner_type])
+            native.genrule(
+                name = "timing_%s_%s" % (corner, corner_type),
+                visibility = ["//visibility:public"],
+                outs = [out_path],
+                srcs = native.glob(["**/*"]),
+                message = "Generating %s timing files, %s corner %s" % (library_name, corner_type, corner),
+                cmd = "$(location @com_google_skywater_pdk//:liberty) %s \"external/com_google_skywater_pdk_%s\" %s > /dev/null && mv \"external/com_google_skywater_pdk_%s/%s\" $@" % (_GENERATOR_ARGUMENT_BY_CORNER_TYPE[corner_type], library_name, corner, library_name, out_path),
+                tools = ["@com_google_skywater_pdk//:liberty"],
+            )
+        native.filegroup(
+            name = "timing_%s_all" % corner,
+            visibility = ["//visibility:public"],
+            srcs = [":timing_%s_%s" % (corner, corner_type) for corner_type in corner_types]
+        )
+    native.filegroup(
+        name = "timing_all",
+        visibility = ["//visibility:public"],
+        srcs = [":timing_%s_all" % corner for corner in corners],
+    )

--- a/dependency_support/com_google_skywater_pdk/liberty_wrapper.py
+++ b/dependency_support/com_google_skywater_pdk/liberty_wrapper.py
@@ -11,15 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Wrapper script for Python scripts in the Skywater PDK.
 
+This is a workaround to allow running scripts that use relative imports even
+though Bazel doesn't run Python binaries with the -m parameter that's required
+to make relative imports work.
+"""
 
-# The structure for adding a third_party dependency is to create a folder in this
-# directory that will contain the build rules and workspace rules required to import
-# it.
-load("//dependency_support/at_clifford_yosys:at_clifford_yosys.bzl", "at_clifford_yosys")
-load("//dependency_support/com_google_skywater_pdk:com_google_skywater_pdk.bzl", "com_google_skywater_pdk")
-
-
-def dependency_support():
-  at_clifford_yosys()
-  com_google_skywater_pdk()
+from skywater_pdk.liberty import main
+main()

--- a/dependency_support/pip_requirements.txt
+++ b/dependency_support/pip_requirements.txt
@@ -1,0 +1,1 @@
+dataclasses-json==0.5.2

--- a/init.bzl
+++ b/init.bzl
@@ -1,0 +1,34 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_python//python:pip.bzl", "pip_install")
+
+def init(python_interpreter=None, python_interpreter_target=None):
+    '''Initializes the bazel_rules_hdl workspace.
+
+    If @bazel_rules_hdl is imported into another Bazel workspace, that workspace
+    must call `init` to allow @bazel_rules_hdl to set itself up.
+
+    `python_interpreter` and `python_interpreter_target` are passed to
+    @bazel_rules_hdl's instance of `pip_install`. They can normally be set to
+    the default None value, but if the outside workspace has a custom Python
+    toolchain configured, these must be set, otherwise @bazel_rules_hdl will
+    not use the right Python toolchain when installing pip dependencies.
+    '''
+    pip_install(
+        name = "com_google_bazel_rules_hdl_pip_deps",
+        requirements = "@com_google_bazel_rules_hdl//dependency_support:pip_requirements.txt",
+        python_interpreter = python_interpreter,
+        python_interpreter_target = python_interpreter_target
+    )


### PR DESCRIPTION
There's no issue for this but @mithro said in private chat that this would be useful to have in this repo.

Note: The Skywater PDK has Python pip dependencies. They are loaded using rules_python, which requires a two-step loading process which AFAIK cannot be hidden from users of bazel_rules_hdl. Bazel workspaces that use bazel_rules_hdl will need to first load it, and then call an init method. I created `init.bzl` for this purpose.