### PR TITLE
Fix hdl-bazel-rules-hdl-push CI configuration

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -60,4 +60,4 @@ steps:
     path: /root/.ssh
 
 substitutions:
-  _USERNAME: $(pull_request.pull_request.user.login)
+  _USERNAME: $(commit.author.login)


### PR DESCRIPTION
Before this PR hdl-bazel-rules-hdl-pr works, but not hdl-bazel-rules-hdl-push.