### PR TITLE
Run CI builds with both GCC and Clang

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -15,7 +15,6 @@
 build --cxxopt "-std=c++17"
 build --host_cxxopt "-std=c++17"
 
-build:ciremotebuild --crosstool_top=@llvm_toolchain//:toolchain
 build:ciremotebuild --bes_backend=grpcs://cloud.buildbuddy.io
 build:ciremotebuild --tls_client_certificate=/root/.ssh/buildbuddy-cert.pem
 build:ciremotebuild --tls_client_key=/root/.ssh/buildbuddy-key.pem

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -32,7 +32,7 @@ steps:
   - name: 'ssh'
     path: /root/.ssh
 
-# Run the build
+# Run the build with Clang
 - name: l.gcr.io/google/bazel:3.5.0
   entrypoint: 'bash'
   args:
@@ -43,11 +43,42 @@ steps:
     python3 tools/generate_uuid.py > test_invocation_id.txt
     echo STATUS: Reporting logs with invocation id $(cat invocation_id.txt) to GitHub.
     bazel run --config=ciremotebuild //tools:report_status_to_github -- \
+        --compiler=Clang \
         --head_sha=${COMMIT_SHA} \
         --build_invocation_id=$(cat build_invocation_id.txt) \
         --test_invocation_id=$(cat test_invocation_id.txt) \
         --github_app_key_file=/root/.ssh/github-app-key-cloud-build-status-reporter.pem
     echo STATUS: Reported logs to GitHub.
+    EXTRA_BAZEL_ARGS="--build_metadata=USER=${_USERNAME} \
+        --config=ciremotebuild \
+        --bes_results_url=https://app.buildbuddy.io/invocation/ \
+        --crosstool_top=@llvm_toolchain//:toolchain" \
+    EXTRA_BUILD_BAZEL_ARGS="--invocation_id=$(cat build_invocation_id.txt)" \
+    EXTRA_TEST_BAZEL_ARGS="--invocation_id=$(cat test_invocation_id.txt)" \
+        tools/test_everything.py
+  timeout: 10800s
+  volumes:
+  - name: 'ssh'
+    path: /root/.ssh
+
+# Run the build with GCC
+- name: l.gcr.io/google/bazel:3.5.0
+  entrypoint: 'bash'
+  args:
+  - '-c'
+  - |
+    set -e
+    python3 tools/generate_uuid.py > build_invocation_id.txt
+    python3 tools/generate_uuid.py > test_invocation_id.txt
+    echo STATUS: Reporting logs with invocation id $(cat invocation_id.txt) to GitHub.
+    bazel run --config=ciremotebuild //tools:report_status_to_github -- \
+        --compiler=GCC \
+        --head_sha=${COMMIT_SHA} \
+        --build_invocation_id=$(cat build_invocation_id.txt) \
+        --test_invocation_id=$(cat test_invocation_id.txt) \
+        --github_app_key_file=/root/.ssh/github-app-key-cloud-build-status-reporter.pem
+    echo STATUS: Reported logs to GitHub.
+    CC=gcc \
     EXTRA_BAZEL_ARGS="--build_metadata=USER=${_USERNAME} \
         --config=ciremotebuild \
         --bes_results_url=https://app.buildbuddy.io/invocation/" \

--- a/tools/report_status_to_github.py
+++ b/tools/report_status_to_github.py
@@ -25,6 +25,7 @@ import time
 
 def parse_arguments():
   parser = argparse.ArgumentParser()
+  parser.add_argument('--compiler', help='The name of the compiler used in the build', required=True)
   parser.add_argument('--head_sha', help='The git hash of the current commit', required=True)
   parser.add_argument('--build_invocation_id', help='Bazel invocation id for building', required=True)
   parser.add_argument('--test_invocation_id', help='Bazel invocation id for testing', required=True)
@@ -62,13 +63,13 @@ def generate_installation_access_token(jwt_token, installation_id):
   response.raise_for_status()
   return response.json()['token']
 
-def report_build_status(installation_access_token, head_sha, invocation_id, invocation_name):
+def report_build_status(installation_access_token, head_sha, invocation_id, compiler, invocation_name):
   log_url = "https://app.buildbuddy.io/invocation/%s" % invocation_id
   response = requests.post('https://api.github.com/repos/hdl/bazel_rules_hdl/check-runs', headers={
     'Authorization': 'token %s' % installation_access_token,
     'Accept': 'application/vnd.github.v3+json',
   }, data=json.dumps({
-    'name': 'Bazel %s Log' % invocation_name,
+    'name': '%s %s Log' % (compiler, invocation_name),
     'head_sha': head_sha,
     'details_url': log_url,
     'status': 'completed',
@@ -86,5 +87,5 @@ private_github_app_key = read_key_file(args.github_app_key_file)
 jwt_token = generate_jwt_token(private_github_app_key)
 installation_id = find_installation_id(jwt_token)
 installation_access_token = generate_installation_access_token(jwt_token, installation_id)
-report_build_status(installation_access_token, args.head_sha, args.build_invocation_id, 'Build')
-report_build_status(installation_access_token, args.head_sha, args.test_invocation_id, 'Test')
+report_build_status(installation_access_token, args.head_sha, args.build_invocation_id, args.compiler, 'Build')
+report_build_status(installation_access_token, args.head_sha, args.test_invocation_id, args.compiler, 'Test')


### PR DESCRIPTION
This first attempt uses the GCC that's preinstalled on the builders. I don't know if that is sufficiently recent.