### PR TITLE
Enable Bazel cache backed by Google Cloud Storage

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -17,6 +17,9 @@ build --host_cxxopt "-std=c++17"
 
 build:ciremotebuild --crosstool_top=@llvm_toolchain//:toolchain
 build:ciremotebuild --bes_backend=grpcs://cloud.buildbuddy.io
+build:ciremotebuild --remote_cache=https://storage.googleapis.com/bazel-cache-rules-hdl
+build:ciremotebuild --google_default_credentials
+build:ciremotebuild --remote_download_toplevel
 build:ciremotebuild --tls_client_certificate=/root/.ssh/buildbuddy-cert.pem
 build:ciremotebuild --tls_client_key=/root/.ssh/buildbuddy-key.pem
 build:ciremotebuild --build_metadata=VISIBILITY=PUBLIC


### PR DESCRIPTION
I tried using Buildbuddy for this, but uploads of some large artifacts time out and fail the whole build. Hopefully GCS will perform better here, either by not having the timeout, or by being faster, let's see.