### PR TITLE
Synthesis: Added the ability to use yosys to synthesize verilog_library rules

### DIFF
--- a/dependency_support/at_clifford_yosys/bundled.BUILD.bazel
+++ b/dependency_support/at_clifford_yosys/bundled.BUILD.bazel
@@ -20,7 +20,7 @@ various application domains.
 
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("@rules_python//python:defs.bzl", "py_binary")
-load("@rules_hdl//dependency_support/at_clifford_yosys:yosys.bzl", "yosys_syntax_check")
+load("@rules_hdl//dependency_support/at_clifford_yosys:yosys.bzl", "yosys_syntax_check", "move_files")
 load("@rules_hdl//dependency_support/com_github_westes_flex:flex.bzl", "genlex")
 load("@rules_hdl//dependency_support/org_gnu_bison:bison.bzl", "genyacc")
 
@@ -221,6 +221,9 @@ cc_binary(
     ],
     copts = YOSYS_COPTS,
     features = ["-use_header_modules"],
+    data = [
+        ":share_files",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         ":kernel",
@@ -228,6 +231,68 @@ cc_binary(
         "@org_gnu_readline//:readline",
     ],
 )
+
+move_files(
+  name = "common_techlibs",
+  srcs = glob([
+    "techlibs/common/*.v",
+  ]),
+  destination = "techlibs",
+)
+
+filegroup(
+  name = "share_files",
+  srcs = glob(
+    include = [
+      "techlibs/common/*.v",
+      "techlibs/**/*.v",
+      "techlibs/**/*.vh",
+      "techlibs/**/*.lib",
+      "techlibs/**/*.txt",
+    ],
+    exclude = [
+      "techlibs/common/*.v",
+    ]
+  ) + [
+    ":common_techlibs"
+  ],
+)
+
+# Fileset(
+#     name = "share_files",
+#     out = "share",
+#     entries = [
+#         # The common files are mapped to the toplevel
+#         FilesetEntry(
+#             files = glob(["techlibs/common/*.v"]),
+#             strip_prefix = "techlibs/common",
+#         ),
+#         # These are vendor specific files in subdirectories.
+#         FilesetEntry(
+#             files = glob(
+#                 include = [
+#                     "techlibs/**/*.v",
+#                     "techlibs/**/*.vh",
+#                     "techlibs/**/*.lib",
+#                     "techlibs/**/*.txt",
+#                 ],
+#                 exclude = ["techlibs/common/**"],
+#             ),
+#             strip_prefix = "techlibs/",
+#         ),
+#         # Generated files.
+#         FilesetEntry(
+#             files = [":xilinx_brams"],
+#             destdir = "xilinx",
+#         ),
+#         # Generated files.
+#         FilesetEntry(
+#             files = [":ice40_brams"],
+#             destdir = "ice40",
+#         ),
+#     ],
+# )
+
 
 yosys_syntax_check(
     name = "testing_yosys_syntax_check_build_rule",

--- a/dependency_support/at_clifford_yosys/bundled.BUILD.bazel
+++ b/dependency_support/at_clifford_yosys/bundled.BUILD.bazel
@@ -258,42 +258,6 @@ filegroup(
   ],
 )
 
-# Fileset(
-#     name = "share_files",
-#     out = "share",
-#     entries = [
-#         # The common files are mapped to the toplevel
-#         FilesetEntry(
-#             files = glob(["techlibs/common/*.v"]),
-#             strip_prefix = "techlibs/common",
-#         ),
-#         # These are vendor specific files in subdirectories.
-#         FilesetEntry(
-#             files = glob(
-#                 include = [
-#                     "techlibs/**/*.v",
-#                     "techlibs/**/*.vh",
-#                     "techlibs/**/*.lib",
-#                     "techlibs/**/*.txt",
-#                 ],
-#                 exclude = ["techlibs/common/**"],
-#             ),
-#             strip_prefix = "techlibs/",
-#         ),
-#         # Generated files.
-#         FilesetEntry(
-#             files = [":xilinx_brams"],
-#             destdir = "xilinx",
-#         ),
-#         # Generated files.
-#         FilesetEntry(
-#             files = [":ice40_brams"],
-#             destdir = "ice40",
-#         ),
-#     ],
-# )
-
-
 yosys_syntax_check(
     name = "testing_yosys_syntax_check_build_rule",
     srcs = [

--- a/dependency_support/at_clifford_yosys/yosys.bzl
+++ b/dependency_support/at_clifford_yosys/yosys.bzl
@@ -36,3 +36,21 @@ def yosys_syntax_check(name, srcs):
         tools = [yosys_binary],
         cmd = "$(location " + yosys_binary + ") -Q -T -p 'read_verilog -sv $(SRCS)' 2>&1 | tee $(OUTS)",
     )
+def _move_files_impl(ctx):
+  outputs = []
+
+  for file in ctx.files.srcs:
+    output = ctx.actions.declare_file(ctx.attr.destination + "/" + file.basename)
+    outputs.append(output)
+    ctx.actions.symlink(output = output, target_file = file)
+
+  return [DefaultInfo(files = depset(outputs))]
+
+
+move_files = rule(
+  implementation = _move_files_impl,
+  attrs = {
+    "srcs": attr.label_list(allow_files = True),
+    "destination": attr.string(default = "", doc = "directory prefix to place files under."),
+  }
+)

--- a/dependency_support/at_clifford_yosys/yosys.bzl
+++ b/dependency_support/at_clifford_yosys/yosys.bzl
@@ -36,21 +36,21 @@ def yosys_syntax_check(name, srcs):
         tools = [yosys_binary],
         cmd = "$(location " + yosys_binary + ") -Q -T -p 'read_verilog -sv $(SRCS)' 2>&1 | tee $(OUTS)",
     )
+
 def _move_files_impl(ctx):
-  outputs = []
+    outputs = []
 
-  for file in ctx.files.srcs:
-    output = ctx.actions.declare_file(ctx.attr.destination + "/" + file.basename)
-    outputs.append(output)
-    ctx.actions.symlink(output = output, target_file = file)
+    for file in ctx.files.srcs:
+        output = ctx.actions.declare_file(ctx.attr.destination + "/" + file.basename)
+        outputs.append(output)
+        ctx.actions.symlink(output = output, target_file = file)
 
-  return [DefaultInfo(files = depset(outputs))]
-
+    return [DefaultInfo(files = depset(outputs))]
 
 move_files = rule(
-  implementation = _move_files_impl,
-  attrs = {
-    "srcs": attr.label_list(allow_files = True),
-    "destination": attr.string(default = "", doc = "directory prefix to place files under."),
-  }
+    implementation = _move_files_impl,
+    attrs = {
+        "srcs": attr.label_list(allow_files = True),
+        "destination": attr.string(default = "", doc = "directory prefix to place files under."),
+    },
 )

--- a/dependency_support/com_google_skywater_pdk/declare_cell_library.bzl
+++ b/dependency_support/com_google_skywater_pdk/declare_cell_library.bzl
@@ -53,4 +53,5 @@ def declare_cell_library(workspace_name, name):
         name = name,
         process_corners = [":{}".format(corner) for corner in corners],
         default_corner = library.get("default_corner", ""),
+        visibility = ["//visibility:public"],
     )

--- a/synthesis/BUILD
+++ b/synthesis/BUILD
@@ -1,0 +1,15 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Empty BUILD file, just to make this directory a Bazel package.

--- a/synthesis/build_defs.bzl
+++ b/synthesis/build_defs.bzl
@@ -1,0 +1,129 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Rules for synthesizing (System)Verilog code."""
+
+load("//pdk:build_defs.bzl", "StandardCellInfo")
+load("//verilog:providers.bzl", "VerilogInfo")
+
+# Args:
+#    standard_cell_info: The StandardCellInfo provider this target was synthesized against.
+#    synthesized_netlist: The structural verilog syntheized with standard_cell_info
+#    top_module: The name of the top level module of the synthesized netlist
+SynthesisInfo = provider("Information about the synthesis target", fields = ["standard_cell_info", "synthesized_netlist", "top_module"])
+
+def _transitive_srcs(deps):
+    return depset(
+        [],
+        transitive = [dep[VerilogInfo].dag for dep in deps],
+    )
+
+def _systhesize_design_impl(ctx):
+    transitive_srcs = _transitive_srcs(ctx.attr.deps)
+    verilog_srcs = [verilog_info_struct.srcs for verilog_info_struct in transitive_srcs.to_list()]
+
+    yosys_script = ctx.actions.declare_file("___yosys.script")
+    verilog_files = [src for sub_tuple in verilog_srcs for src in sub_tuple]
+    read_verilog_lines = "\n".join(["read_verilog -sv -defer {}".format(src.path) for src in verilog_files])
+
+    output_file = ctx.actions.declare_file("{}_synth_output.v".format(ctx.attr.name))
+    default_liberty_file = ctx.attr.standard_cells[StandardCellInfo].default_corner.liberty
+    yosys_script_content = """
+# read design
+{verilog_statements}
+
+# generic synthesis
+synth -top {top_module}
+
+# mapping to liberty
+dfflibmap -liberty {liberty}
+abc -liberty {liberty}
+
+# write synthesized design
+write_verilog {output}
+    """.format(
+        output_file.path,
+        verilog_statements = read_verilog_lines,
+        top_module = ctx.attr.top_module,
+        liberty = default_liberty_file.path,
+        output = output_file.path,
+    )
+
+    ctx.actions.write(yosys_script, yosys_script_content)
+
+    inputs = []
+    inputs.extend(verilog_files)
+    inputs.append(yosys_script)
+
+    (tool_inputs, _) = ctx.resolve_tools(tools = [ctx.attr.yosys_tool])
+
+    yosys_runfiles_dir = ctx.executable.yosys_tool.path + ".runfiles"
+
+    log_file = ctx.actions.declare_file("{}_yosys_output.log".format(ctx.attr.name))
+
+    args = ctx.actions.args()
+    args.add("-q")  # quiet mode only errors printed to stderr
+    args.add("-q")  # second q don't print warnings
+    args.add("-Q")  # Don't print header
+    args.add("-T")  # Don't print footer
+    args.add_all("-l", [log_file])  # put output in log file
+    args.add_all("-s", [yosys_script])  # command execution
+
+    ctx.actions.run(
+        outputs = [output_file, log_file],
+        inputs = inputs + tool_inputs.to_list() + [default_liberty_file],
+        arguments = [args],
+        executable = ctx.executable.yosys_tool,
+        tools = [
+            ctx.executable._abc,
+        ],
+        env = {
+            "YOSYS_DATDIR": yosys_runfiles_dir + "/at_clifford_yosys/techlibs/",
+            "ABC": ctx.executable._abc.path,
+        },
+        mnemonic = "SythesizingRTL",
+    )
+
+    return [
+        DefaultInfo(files = depset([output_file, log_file])),
+        SynthesisInfo(
+            standard_cell_info = ctx.attr.standard_cells[StandardCellInfo],
+            synthesized_netlist = output_file,
+            top_module = ctx.attr.top_module,
+        ),
+    ]
+
+synthesize_rtl = rule(
+    implementation = _systhesize_design_impl,
+    attrs = {
+        "srcs": attr.label_list(allow_files = True),
+        "standard_cells": attr.label(
+            providers = [StandardCellInfo],
+            default = "@com_google_skywater_pdk_sky130_fd_sc_hd//:sky130_fd_sc_hd",
+        ),
+        "deps": attr.label_list(providers = [VerilogInfo]),
+        "top_module": attr.string(default = "top"),
+        "yosys_tool": attr.label(
+            default = Label("@at_clifford_yosys//:yosys"),
+            executable = True,
+            cfg = "exec",
+        ),
+        "_abc": attr.label(
+            default = Label("@edu_berkeley_abc//:abc"),
+            executable = True,
+            cfg = "exec",
+        )
+    },
+)

--- a/synthesis/build_defs.bzl
+++ b/synthesis/build_defs.bzl
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 """Rules for synthesizing (System)Verilog code."""
 
 load("//pdk:build_defs.bzl", "StandardCellInfo")
@@ -124,6 +123,6 @@ synthesize_rtl = rule(
             default = Label("@edu_berkeley_abc//:abc"),
             executable = True,
             cfg = "exec",
-        )
+        ),
     },
 )

--- a/synthesis/tests/BUILD
+++ b/synthesis/tests/BUILD
@@ -1,0 +1,32 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+load("//synthesis:build_defs.bzl", "synthesize_rtl")
+load("//verilog:providers.bzl", "verilog_library")
+
+synthesize_rtl(
+  name = "verilog_adder_synthesized",
+  deps = [
+    ":verilog_adder",
+  ],
+  top_module = "adder",
+)
+
+verilog_library(
+  name = "verilog_adder",
+  srcs = [
+    "verilog_adder.v",
+  ]
+)

--- a/synthesis/tests/BUILD
+++ b/synthesis/tests/BUILD
@@ -12,21 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 load("//synthesis:build_defs.bzl", "synthesize_rtl")
 load("//verilog:providers.bzl", "verilog_library")
 
 synthesize_rtl(
-  name = "verilog_adder_synthesized",
-  deps = [
-    ":verilog_adder",
-  ],
-  top_module = "adder",
+    name = "verilog_adder_synthesized",
+    top_module = "adder",
+    deps = [
+        ":verilog_adder",
+    ],
 )
 
 verilog_library(
-  name = "verilog_adder",
-  srcs = [
-    "verilog_adder.v",
-  ]
+    name = "verilog_adder",
+    srcs = [
+        "verilog_adder.v",
+    ],
 )

--- a/synthesis/tests/verilog_adder.v
+++ b/synthesis/tests/verilog_adder.v
@@ -1,0 +1,24 @@
+//Copyright 2021 Google LLC
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+
+module adder(
+  input [7:0] x,
+  input [7:0] y,
+  input carry_in,
+  output carry_output_bit,
+  output [7:0] sum,
+);
+  assign {carry_output_bit, sum} = x + y + carry_in;
+endmodule

--- a/verilog/BUILD
+++ b/verilog/BUILD
@@ -1,0 +1,15 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Empty BUILD file, just to make this directory a Bazel package.

--- a/verilog/providers.bzl
+++ b/verilog/providers.bzl
@@ -1,0 +1,110 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# WARNING: prefer using 'merge_verilog_info' rather than constructing these directly
+# to ensure the depset ordering is correct.
+VerilogInfo = provider(
+    doc = "Contains DAG info per node in a struct.",
+    fields = {
+        "dag": "A depset of the DAG entries to propagate upwards.",
+        "plis": "a depset of VerilogInterfaceInfo",
+    },
+)
+
+def make_dag_entry(srcs, deps, label):
+    """Create a new DAG entry for use in VerilogInfo.
+
+    As VerilogInfo should be created via 'merge_verilog_info' (rather than directly),
+    the new entries being passed in should be created with this function in order to
+    ensure the struct contains the correct fields.
+
+    Any fields marked 'legacy' are under immediate plans to be deprecated. New uses
+    should be avoided. Fields marked as 'experimental' are more likely to experience
+    changes in semantics in the future. Future users should exercise caution before
+    using them and consider consulting the rule maintainers first.
+
+    Args:
+      srcs: A list of File that are 'srcs'.
+      deps = tuple(deps)
+      experimental_exclusion_list_files: A list of File that declare file names to exclude
+    Returns:
+      struct with all these fields properly stored.
+    """
+    return struct(
+        srcs = tuple(srcs),
+        deps = tuple(deps),
+        label = label,
+    )
+
+def make_verilog_info(
+        new_entries = (),
+        old_infos = ()):
+    """Return a new VerilogInfo that merges other VerilogInfo and new DAG entries.
+
+    WARNING: Prefer using this function instead of manually creating or merging
+    VerilogInfo providers to ensure the DAG traversal ordering is correct.
+
+    Note: It is expected that the new DAG entries point to entries in the other
+    VerilogInfo (but this is not required or enforced).
+
+    Args:
+      new_entries: list of DAG entries (from 'make_dag_entry') to add to the DAG
+      old_infos: list of VerilogInfo that hold other parts of the DAG
+      # plis: Verilog PLI/VPI files.
+      # dpis: Verilog DPI files.
+    Returns:
+      VerilogInfo that combines all the DAGs together.
+      """
+    return VerilogInfo(
+        dag = depset(
+            direct = new_entries,
+            order = "postorder",
+            transitive = [x.dag for x in old_infos],
+        ),
+    )
+
+def _produce_dag_impl(ctx):
+    """Produces a DAG for the given verilog_X target.
+
+    Args:
+      ctx: The context for this rule.
+
+    Returns:
+      A struct containing the DAG at this level of the dependency graph.
+    """
+
+    verilog_info = make_verilog_info(
+        new_entries = [make_dag_entry(
+            srcs = ctx.files.srcs,
+            deps = ctx.attr.deps,
+            label = ctx.label,
+        )],
+        old_infos = [dep[VerilogInfo] for dep in ctx.attr.deps],
+    )
+
+    return [
+        verilog_info,
+    ]
+
+
+verilog_library = rule(
+    attrs = {
+        "srcs": attr.label_list(allow_files = True),
+        "deps": attr.label_list(providers = [
+            VerilogInfo,
+        ]),
+    },
+    implementation = _produce_dag_impl,
+)

--- a/verilog/providers.bzl
+++ b/verilog/providers.bzl
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Describe Verilog providers and some helpful functions for manipulating them."""
 
 # WARNING: prefer using 'merge_verilog_info' rather than constructing these directly
 # to ensure the depset ordering is correct.
@@ -37,8 +38,8 @@ def make_dag_entry(srcs, deps, label):
 
     Args:
       srcs: A list of File that are 'srcs'.
-      deps = tuple(deps)
-      experimental_exclusion_list_files: A list of File that declare file names to exclude
+      deps: A list of Label that are deps of this entry.
+      label: A Label to use as the name for this entry.
     Returns:
       struct with all these fields properly stored.
     """
@@ -97,7 +98,6 @@ def _produce_dag_impl(ctx):
     return [
         verilog_info,
     ]
-
 
 verilog_library = rule(
     attrs = {


### PR DESCRIPTION
This PR introduces two major concepts
	* verilog_library and its associated providers.
	* synthesize_rtl which takes a PDK and generates a synthesized
	netlist.

Both rules generate consumable providers that can be used by downstream
rules.