### PR TITLE
[synthesis] Fix tool imports of abc in yosys

### DIFF
--- a/dependency_support/at_clifford_yosys/bundled.BUILD.bazel
+++ b/dependency_support/at_clifford_yosys/bundled.BUILD.bazel
@@ -223,6 +223,7 @@ cc_binary(
     features = ["-use_header_modules"],
     data = [
         ":share_files",
+        "@edu_berkeley_abc//:abc",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/dependency_support/net_invisible_island_ncurses/net_invisible_island_ncurses.bzl
+++ b/dependency_support/net_invisible_island_ncurses/net_invisible_island_ncurses.bzl
@@ -22,7 +22,9 @@ def net_invisible_island_ncurses():
         http_archive,
         name = "net_invisible_island_ncurses",
         urls = [
-            "https://invisible-mirror.net/archives/ncurses/ncurses-6.2.tar.gz",
+            "https://ftp.gnu.org/gnu/ncurses/ncurses-6.2.tar.gz",
+            "https://fossies.org/linux/misc/ncurses-6.2.tar.gz",
+            "http://ftp.vim.org/ftp/gnu/ncurses/ncurses-6.2.tar.gz",
         ],
         strip_prefix = "ncurses-6.2",
         sha256 = "30306e0c76e0f9f1f0de987cf1c82a5c21e1ce6568b9227f7da5b71cbea86c9d",

--- a/dependency_support/org_gnu_readline/org_gnu_readline.bzl
+++ b/dependency_support/org_gnu_readline/org_gnu_readline.bzl
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2020-2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,16 +14,20 @@
 
 """Registers Bazel workspaces for the GNU readline library."""
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
 def org_gnu_readline():
     maybe(
-        new_git_repository,
+        http_archive,
         name = "org_gnu_readline",
-        commit = "8e6ccd0373d77b86ed37a9a7d232ccfea3d6670c",  # 8.0, 2020-08-24
-        remote = "https://git.savannah.gnu.org/git/readline.git",
-        shallow_since = "1546871421 -0500",
+        urls = [
+          "https://ftp.gnu.org/gnu/readline/readline-8.0.tar.gz",
+          "http://ftp.vim.org/ftp/gnu/readline/readline-8.0.tar.gz",
+          "http://ftp.swin.edu.au/gnu/readline/readline-8.0.tar.gz",
+        ],
+        sha256 =  "e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461",
+        strip_prefix = "readline-8.0",
         build_file = Label("//dependency_support/org_gnu_readline:bundled.BUILD.bazel"),
         patches = [
             "@rules_hdl//dependency_support/org_gnu_readline:missing_include.patch",

--- a/synthesis/build_defs.bzl
+++ b/synthesis/build_defs.bzl
@@ -66,7 +66,7 @@ write_verilog {output}
     inputs.extend(verilog_files)
     inputs.append(yosys_script)
 
-    (tool_inputs, _) = ctx.resolve_tools(tools = [ctx.attr.yosys_tool])
+    (tool_inputs, input_manifests) = ctx.resolve_tools(tools = [ctx.attr.yosys_tool])
 
     yosys_runfiles_dir = ctx.executable.yosys_tool.path + ".runfiles"
 
@@ -85,12 +85,11 @@ write_verilog {output}
         inputs = inputs + tool_inputs.to_list() + [default_liberty_file],
         arguments = [args],
         executable = ctx.executable.yosys_tool,
-        tools = [
-            ctx.executable._abc,
-        ],
+        tools = tool_inputs,
+        input_manifests = input_manifests,
         env = {
             "YOSYS_DATDIR": yosys_runfiles_dir + "/at_clifford_yosys/techlibs/",
-            "ABC": ctx.executable._abc.path,
+            "ABC": yosys_runfiles_dir + "/edu_berkeley_abc/abc",
         },
         mnemonic = "SythesizingRTL",
     )
@@ -116,11 +115,6 @@ synthesize_rtl = rule(
         "top_module": attr.string(default = "top"),
         "yosys_tool": attr.label(
             default = Label("@at_clifford_yosys//:yosys"),
-            executable = True,
-            cfg = "exec",
-        ),
-        "_abc": attr.label(
-            default = Label("@edu_berkeley_abc//:abc"),
             executable = True,
             cfg = "exec",
         ),


### PR DESCRIPTION
This change allows you to drop the direct dependency on abc in the synthesis rule.