### PR TITLE
Add tar file targets that package openroad and yosys with their runfiles

### DIFF
--- a/place_and_route/BUILD
+++ b/place_and_route/BUILD
@@ -13,3 +13,14 @@
 # limitations under the License.
 
 # Place and Route package.
+
+# rules_pkg won't work before Bazel 4 because it depends on the json API.
+# load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+
+pkg_tar(
+    name = "openroad",
+    srcs = ["@org_theopenroadproject//:openroad"],
+    include_runfiles = True,
+    strip_prefix = "/../",
+)

--- a/synthesis/BUILD
+++ b/synthesis/BUILD
@@ -12,4 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Empty BUILD file, just to make this directory a Bazel package.
+# rules_pkg won't work before Bazel 4 because it depends on the json API.
+# load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+
+pkg_tar(
+    name = "yosys",
+    srcs = ["@at_clifford_yosys//:yosys"],
+    include_runfiles = True,
+    strip_prefix = "/../",
+)


### PR DESCRIPTION
This uses the deprecated pkg_tar instead of rules_pkg for Bazel 3.5 compatibility.

This is the Bazel 3.5 compatible version of https://github.com/hdl/bazel_rules_hdl/pull/60