### PR TITLE
Replace ftp.pcre.org with a different source for pcre 8.44 

### DIFF
--- a/dependency_support/org_pcre_ftp/org_pcre_ftp.bzl
+++ b/dependency_support/org_pcre_ftp/org_pcre_ftp.bzl
@@ -22,7 +22,7 @@ def org_pcre_ftp():
         http_archive,
         name = "org_pcre_ftp",
         urls = [
-            "https://ftp.pcre.org/pub/pcre/pcre-8.44.tar.gz",
+            "https://ftp.exim.org/pub/pcre/pcre-8.44.tar.gz",
         ],
         strip_prefix = "pcre-8.44",
         sha256 = "aecafd4af3bd0f3935721af77b889d9024b2e01d96b58471bd91a3063fb47728",


### PR DESCRIPTION
In the download section, https://www.pcre.org/ makes it clear that ftp.pcre.org is down permanently, so we need a different source for pcre-8.44. Unlike pcre2, we can't get pcre from GitHub because it is no longer maintained.

In the bigger picture, we probably want to replace pcre with something else now that it is end-of-life (or stop using it the way Tensorflow did: https://github.com/tensorflow/tensorflow/pull/49023). That being said, getting the same pcre tarball from somewhere else will at least unbreak our CI so it's worth doing.