### PR TITLE
place_and_route: Fixes conflict error when multiple targets with varying parameters

### DIFF
--- a/place_and_route/open_road.bzl
+++ b/place_and_route/open_road.bzl
@@ -118,7 +118,7 @@ def openroad_command(ctx, commands, input_db = None, step_name = None, inputs = 
         write_db = "write_db {}".format(output_db.path),
     )
 
-    file_name = "{}{}.tcl".format(input_hash, command_hash)
+    file_name = "{}_script.tcl".format(output_db.basename[:-(len(output_db.extension) + 1)])
     command_file = ctx.actions.declare_file(file_name)
     ctx.actions.write(command_file, content = command)
 


### PR DESCRIPTION
This addresses some errors users were seeing when running slight
variations on existing configurations.

It's caused because by default the rules use the hash of the inputs to name intermediate outputs which can often be the same name.