### PR TITLE
Read liberty in detailed_routing bzl

### DIFF
--- a/place_and_route/private/detailed_routing.bzl
+++ b/place_and_route/private/detailed_routing.bzl
@@ -15,7 +15,7 @@
 """Detailed Routing openROAD commands"""
 
 load("//place_and_route:open_road.bzl", "OpenRoadInfo", "merge_open_road_info", "openroad_command")
-load("//third_party/bazel_rules_hdl:synthesis/build_defs.bzl", "SynthesisInfo")
+load("//synthesis/build_defs.bzl", "SynthesisInfo")
 
 def _triton_route_parameter_file(ctx, open_road_info):
     triton_route_parameter_file = ctx.actions.declare_file("{}_triton_route_params.params".format(ctx.attr.name))

--- a/place_and_route/private/detailed_routing.bzl
+++ b/place_and_route/private/detailed_routing.bzl
@@ -15,6 +15,7 @@
 """Detailed Routing openROAD commands"""
 
 load("//place_and_route:open_road.bzl", "OpenRoadInfo", "merge_open_road_info", "openroad_command")
+load("//third_party/bazel_rules_hdl:synthesis/build_defs.bzl", "SynthesisInfo")
 
 def _triton_route_parameter_file(ctx, open_road_info):
     triton_route_parameter_file = ctx.actions.declare_file("{}_triton_route_params.params".format(ctx.attr.name))

--- a/place_and_route/private/detailed_routing.bzl
+++ b/place_and_route/private/detailed_routing.bzl
@@ -15,7 +15,7 @@
 """Detailed Routing openROAD commands"""
 
 load("//place_and_route:open_road.bzl", "OpenRoadInfo", "merge_open_road_info", "openroad_command")
-load("//synthesis/build_defs.bzl", "SynthesisInfo")
+load("//synthesis:build_defs.bzl", "SynthesisInfo")
 
 def _triton_route_parameter_file(ctx, open_road_info):
     triton_route_parameter_file = ctx.actions.declare_file("{}_triton_route_params.params".format(ctx.attr.name))

--- a/place_and_route/private/detailed_routing.bzl
+++ b/place_and_route/private/detailed_routing.bzl
@@ -58,10 +58,14 @@ def detailed_routing(ctx, open_road_info):
 
     """
 
+    liberty = ctx.attr.synthesized_rtl[SynthesisInfo].standard_cell_info.default_corner.liberty
     trition_route_params = _triton_route_parameter_file(ctx, open_road_info)
     routed_def = ctx.actions.declare_file("{}_detail_routed.def".format(ctx.attr.name))
 
     open_road_commands = [
+        "read_liberty {liberty_file}".format(
+            liberty_file = liberty.path,
+        ),
         "set_thread_count [exec getconf _NPROCESSORS_ONLN]",
         "detailed_route -param {tr_parameter_file}".format(
             tr_parameter_file = trition_route_params["triton_route_parameter_file"].path,
@@ -72,6 +76,7 @@ def detailed_routing(ctx, open_road_info):
     ]
 
     inputs = [
+        liberty,
         trition_route_params["triton_route_parameter_file"],
         open_road_info.routing_guide,
     ]


### PR DESCRIPTION
Liberty should be read to make the flow complete. For example, report_power or report_design_area commands cannot be executed with this.