### PR TITLE
at_clifford_yosys: replace ternary "-D" with patch, ncurses: cp with "-f" to deal with unsandboxed cases 

### DIFF
--- a/dependency_support/at_clifford_yosys/at_clifford_yosys.bzl
+++ b/dependency_support/at_clifford_yosys/at_clifford_yosys.bzl
@@ -27,4 +27,7 @@ def at_clifford_yosys():
         strip_prefix = "yosys-95c60866813e520da48c628d4f98a2fe2cb4db25",
         sha256 = "bdeaabd03db2c90b040edc6c6616b573f7712224a0ff7722c8f6c9cf2d490431",
         build_file = Label("@rules_hdl//dependency_support:at_clifford_yosys/bundled.BUILD.bazel"),
+        patches = [
+            Label("@rules_hdl//dependency_support:at_clifford_yosys/yosys.patch"),
+        ],
     )

--- a/dependency_support/at_clifford_yosys/bundled.BUILD.bazel
+++ b/dependency_support/at_clifford_yosys/bundled.BUILD.bazel
@@ -127,7 +127,6 @@ GENERATED_HEADERS = [
 
 YOSYS_COPTS = [
     "-DYOSYS_SRC='\"./\"'",
-    "-DYOSYS_DATDIR='std::getenv(\"YOSYS_DATDIR\") ? std::getenv(\"YOSYS_DATDIR\") : \".\"'",
     "-fexceptions",
     "-Wno-error",
     "-Wno-implicit-fallthrough",

--- a/dependency_support/at_clifford_yosys/yosys.patch
+++ b/dependency_support/at_clifford_yosys/yosys.patch
@@ -1,0 +1,18 @@
+--- kernel/yosys.cc
++++ kernel/yosys.cc
+@@ -863,13 +863,12 @@ void init_share_dirname()
+ 		yosys_share_dirname = proc_share_path;
+ 		return;
+ 	}
+-#    ifdef YOSYS_DATDIR
+-	proc_share_path = YOSYS_DATDIR "/";
++	const char* env_datdir = std::getenv("YOSYS_DATDIR");
++	proc_share_path = env_datdir != nullptr ? env_datdir : "./";
+ 	if (check_file_exists(proc_share_path, true)) {
+ 		yosys_share_dirname = proc_share_path;
+ 		return;
+ 	}
+-#    endif
+ #  endif
+ }
+ #endif

--- a/dependency_support/net_invisible_island_ncurses/bundled.BUILD.bazel
+++ b/dependency_support/net_invisible_island_ncurses/bundled.BUILD.bazel
@@ -227,7 +227,7 @@ genrule(
         "include/Caps",
     ],
     outs = ["ncurses/comp_captab.c"],
-    cmd = "cp $(location :make_hash) . && $(location :ncurses/tinfo/MKcaptab.sh) $$(which awk) 1 $(location :ncurses/tinfo/MKcaptab.awk) $(location :include/Caps) > $@",
+    cmd = "cp -f $(location :make_hash) . && $(location :ncurses/tinfo/MKcaptab.sh) $$(which awk) 1 $(location :ncurses/tinfo/MKcaptab.awk) $(location :include/Caps) > $@",
 )
 
 genrule(
@@ -238,7 +238,7 @@ genrule(
         "ncurses/tinfo/MKuserdefs.sh",
     ] + CAPLIST,
     outs = ["ncurses/comp_userdefs.c"],
-    cmd = "cp $(location :make_hash) . && $(location ncurses/tinfo/MKuserdefs.sh) $$(which awk) 1 " + CAPLIST_LOCATIONS + " > $@",
+    cmd = "cp -f $(location :make_hash) . && $(location ncurses/tinfo/MKuserdefs.sh) $$(which awk) 1 " + CAPLIST_LOCATIONS + " > $@",
 )
 
 genrule(


### PR DESCRIPTION
at_clifford_yosys: replace ternary "-D" with patch (fix #73):

```
There seems to be a regression (or behavior change) with Bazel 4.2.2 in string escaping or copts sanitization.
```

ncurses: cp with "-f" to deal with unsandboxed cases:

```
Fixes: "cp: cannot create regular file './make_hash': File exists"

This issue only happens when Bazel runs with unsandboxed strategies
like "local" or "standalone".

On some platforms (e.g. macOS), debug symbols of compiled binaries
are stored in separate file(s). Bazel fails to preserve those files
in sandboxed mode (default). In other cases, we may wish to inspect
the intermediate files generated during an action. As such, it is
often necessary to run Bazel with unsandboxed strategies.
```