### PR TITLE
Remove the {power|area}_results OpenRoadInfo fields. Moving forward, the more precise fields should be used instead.

### DIFF
--- a/place_and_route/open_road.bzl
+++ b/place_and_route/open_road.bzl
@@ -27,9 +27,6 @@ OpenRoadInfo = provider(
         "general_routing_power_results",
         "general_routing_area_results",
         "logs",
-        # TODO: These are only kept to not break OpenROAD power/area testing. Remove them asap.
-        "power_results",
-        "area_results",
     ],
 )
 
@@ -72,9 +69,6 @@ def merge_open_road_info(left, right):
     general_routing_power_results = _merge_right(left, right, "general_routing_power_results")
     general_routing_area_results = _merge_right(left, right, "general_routing_area_results")
 
-    power_results = _merge_right(left, right, "power_results")
-    area_results = _merge_right(left, right, "area_results")
-
     return OpenRoadInfo(
         commands = left.commands + right.commands,
         input_files = depset([], transitive = [left.input_files, right.input_files]),
@@ -86,8 +80,6 @@ def merge_open_road_info(left, right):
         verilog_based_area_results = verilog_based_area_results,
         general_routing_power_results = general_routing_power_results,
         general_routing_area_results = general_routing_area_results,
-        power_results = power_results,
-        area_results = area_results,
     )
 
 def openroad_command(ctx, commands, input_db = None, step_name = None, inputs = [], outputs = [], execution_requirements = {}):

--- a/place_and_route/private/floorplan.bzl
+++ b/place_and_route/private/floorplan.bzl
@@ -88,7 +88,7 @@ def init_floor_plan(ctx):
         _initialize_floorplan_command(ctx),
         "source {tracks_file}".format(
             tracks_file = open_road_configuration.tracks_file.path,
-        )
+        ),
     ])
     open_road_commands.extend(generate_power_results(ctx, verilog_based_power_results))
     open_road_commands.extend(generate_area_results(verilog_based_area_results))

--- a/place_and_route/private/global_routing.bzl
+++ b/place_and_route/private/global_routing.bzl
@@ -124,8 +124,6 @@ foreach layer_adjustment {global_routing_layer_adjustments} {{
         routing_guide = route_guide,
         general_routing_power_results = general_routing_power_results,
         general_routing_area_results = general_routing_area_results,
-        power_results = general_routing_power_results,
-        area_results = general_routing_area_results,
     )
 
     return merge_open_road_info(open_road_info, current_action_open_road_info)


### PR DESCRIPTION
Remove the {power|area}_results OpenRoadInfo fields. Moving forward, the more precise fields should be used instead.
