### PR TITLE
Fixes observed nondeterminism in synthesis

### DIFF
--- a/synthesis/synth.tcl
+++ b/synthesis/synth.tcl
@@ -33,9 +33,9 @@ set liberty $::env(LIBERTY)
 dfflibmap -liberty $liberty
 
 if { [info exists ::env(CLOCK_PERIOD) ] } {
-  abc -liberty $liberty -dff -g aig -D $::env(CLOCK_PERIOD)
+  abc -liberty $liberty -g aig -D $::env(CLOCK_PERIOD)
 } else {
-  abc -liberty $liberty -dff -g aig
+  abc -liberty $liberty -g aig
 }
 
 # write synthesized design


### PR DESCRIPTION
The dff flag passed to abc appears to cause non-determinism in the generated netlist.