### PR TITLE
Add analysis binaries to support XLS Sky130 and ASAP7 process characterization

### DIFF
--- a/flows/analysis/BUILD.bazel
+++ b/flows/analysis/BUILD.bazel
@@ -63,3 +63,19 @@ analyze_rtl_binary(
     constants = ["clock_port"],
     standard_cells = "@org_theopenroadproject_asap7//:asap7_rvt_1x",
 )
+
+analyze_rtl_binary(
+    name = "characterize_sky130",
+    analysis_script = "characterize.tcl",
+    constants = ["clock_port", "clock_period_ps"],
+    outputs = ["metrics"],
+    standard_cells = "@com_google_skywater_pdk_sky130_fd_sc_hd//:sky130_fd_sc_hd",
+)
+
+analyze_rtl_binary(
+    name = "characterize_asap7",
+    analysis_script = "characterize.tcl",
+    constants = ["clock_port", "clock_period_ps"],
+    outputs = ["metrics"],
+    standard_cells = "@org_theopenroadproject_asap7//:asap7_rvt_1x",
+)

--- a/flows/analysis/characterize.tcl
+++ b/flows/analysis/characterize.tcl
@@ -1,0 +1,17 @@
+puts stderr "OpenROAD analysis started\n"
+read_verilog $::env(INPUT_NETLIST)
+link_design $::env(CONSTANT_TOP)
+
+set clock_port $::env(CONSTANT_CLOCK_PORT)
+
+set_cmd_units -time ps
+
+create_clock -name $clock_port [get_ports $clock_port] -period $::env(CONSTANT_CLOCK_PERIOD_PS)
+
+set timing_paths [find_timing_paths -sort_by_slack]
+
+set critical_path [lindex $timing_paths 0]
+
+utl::metric "slack_ps" [get_property $critical_path slack]
+
+puts stderr "OpenROAD analysis done\n"

--- a/flows/analysis/simple_synth.tcl
+++ b/flows/analysis/simple_synth.tcl
@@ -19,7 +19,7 @@ dfflibmap -liberty $liberty
 
 # -keepff ensures that there will be nets for the source registers
 # in the netlist output, supporting further analysis
-abc -liberty $liberty -dff -g aig -keepff
+abc -liberty $liberty -g aig -keepff
 
 # write synthesized design
 set output $::env(OUTPUT_NETLIST)

--- a/flows/openroad/build_defs.bzl
+++ b/flows/openroad/build_defs.bzl
@@ -48,6 +48,10 @@ def assemble_openroad_step(
         "-no_init",
         "-no_splash",
         "-exit",
+        # Put metrics in a default file if the output location is not set.
+        "-metrics ${{OUTPUT_METRICS:-{name}_metrics.json}}".format(
+            name = ctx.attr.name,
+        ),
         "${RUNFILES}/" + script_file.short_path,
     ]
 
@@ -70,10 +74,13 @@ def assemble_openroad_step(
 
     openroad_runfiles = ctx.attr._openroad[DefaultInfo].default_runfiles
 
+    # Any openroad step can produce a metrics JSON file
+    full_outputs = outputs if "metrics" in outputs else outputs + ["metrics"]
+
     return [
         FlowStepInfo(
             inputs = inputs,
-            outputs = outputs,
+            outputs = full_outputs,
             constants = constants,
             executable_type = "openroad",
             arguments = [],  # ["-quiet"], # Run quietly when part of a larger flow.


### PR DESCRIPTION
These are analysis binaries that take input RTL and put the slack in ps (positive or negative) in a "slack_ps" metric, to be compatible with process characterization using the characterization server at https://github.com/google/xls/tree/main/xls/synthesis/openroad