### PR TITLE
org_gnu_gnulib: backport "c-stack: stop using SIGSTKSZ"

### DIFF
--- a/dependency_support/org_gnu_gnulib/org_gnu_gnulib.bzl
+++ b/dependency_support/org_gnu_gnulib/org_gnu_gnulib.bzl
@@ -119,6 +119,8 @@ static const char * _replaced_get_charset_aliases (void)
         "static _Noreturn void": "static _Noreturn __attribute_noreturn__ void",
     })
 
+    ctx.patch(Label("@rules_hdl//dependency_support/org_gnu_gnulib:stop_using_sigstksz.patch"))
+
 _org_gnu_gnulib = repository_rule(
     __org_gnu_gnulib,
 )

--- a/dependency_support/org_gnu_gnulib/stop_using_sigstksz.patch
+++ b/dependency_support/org_gnu_gnulib/stop_using_sigstksz.patch
@@ -1,0 +1,126 @@
+From 340f769ae85512413819f64a57e077ee85b7026e Mon Sep 17 00:00:00 2001
+From: Paul Eggert <eggert@cs.ucla.edu>
+Date: Wed, 30 Sep 2020 13:50:36 -0700
+Subject: [PATCH] c-stack: stop using SIGSTKSZ
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+It’s been proposed to stop making SIGSTKSZ an integer constant:
+https://sourceware.org/pipermail/libc-alpha/2020-September/118028.html
+Also, using SIGSTKSZ in #if did not conform to current POSIX.
+Also, avoiding SIGSTKSZ makes the code simpler and easier to grok.
+* lib/c-stack.c (SIGSTKSZ): Remove.
+(alternate_signal_stack): Now a 64 KiB array, for simplicity.
+All uses changed.
+---
+ lib/c-stack.c | 47 ++++++++++++++++++-----------------------------
+ lib/c-stack.h |  2 +-
+ 2 files changed, 19 insertions(+), 30 deletions(-)
+
+diff --git lib/c-stack.c lib/c-stack.c
+index f50a4a5dc..9352ffef0 100644
+--- lib/c-stack.c
++++ lib/c-stack.c
+@@ -50,16 +50,8 @@
+ #if ! HAVE_STACK_T && ! defined stack_t
+ typedef struct sigaltstack stack_t;
+ #endif
+-#ifndef SIGSTKSZ
+-# define SIGSTKSZ 16384
+-#elif HAVE_LIBSIGSEGV && SIGSTKSZ < 16384
+-/* libsigsegv 2.6 through 2.8 have a bug where some architectures use
+-   more than the Linux default of an 8k alternate stack when deciding
+-   if a fault was caused by stack overflow.  */
+-# undef SIGSTKSZ
+-# define SIGSTKSZ 16384
+-#endif
+ 
++#include <stddef.h>
+ #include <stdlib.h>
+ #include <string.h>
+ 
+@@ -89,6 +81,16 @@ typedef struct sigaltstack stack_t;
+ # endif
+ #endif
+ 
++/* Storage for the alternate signal stack.
++   64 KiB is not too large for Gnulib-using apps, and is large enough
++   for all known platforms.  Smaller sizes may run into trouble.
++   For example, libsigsegv 2.6 through 2.8 have a bug where some
++   architectures use more than the Linux default of an 8 KiB alternate
++   stack when deciding if a fault was caused by stack overflow.  */
++static max_align_t alternate_signal_stack[(64 * 1024
++                                           + sizeof (max_align_t) - 1)
++                                          / sizeof (max_align_t)];
++
+ /* The user-specified action to take when a SEGV-related program error
+    or stack overflow occurs.  */
+ static _GL_ASYNC_SAFE void (* volatile segv_action) (int);
+@@ -135,19 +137,6 @@ die (int signo)
+ #if (HAVE_SIGALTSTACK && HAVE_DECL_SIGALTSTACK \
+      && HAVE_STACK_OVERFLOW_HANDLING) || HAVE_LIBSIGSEGV
+ 
+-/* Storage for the alternate signal stack.  */
+-static union
+-{
+-  char buffer[SIGSTKSZ];
+-
+-  /* These other members are for proper alignment.  There's no
+-     standard way to guarantee stack alignment, but this seems enough
+-     in practice.  */
+-  long double ld;
+-  long l;
+-  void *p;
+-} alternate_signal_stack;
+-
+ static _GL_ASYNC_SAFE void
+ null_action (int signo _GL_UNUSED)
+ {
+@@ -214,8 +203,8 @@ c_stack_action (_GL_ASYNC_SAFE void (*action) (int))
+ 
+   /* Always install the overflow handler.  */
+   if (stackoverflow_install_handler (overflow_handler,
+-                                     alternate_signal_stack.buffer,
+-                                     sizeof alternate_signal_stack.buffer))
++                                     alternate_signal_stack,
++                                     sizeof alternate_signal_stack))
+     {
+       errno = ENOTSUP;
+       return -1;
+@@ -287,14 +276,14 @@ c_stack_action (_GL_ASYNC_SAFE void (*action) (int))
+   stack_t st;
+   struct sigaction act;
+   st.ss_flags = 0;
++  st.ss_sp = alternate_signal_stack;
++  st.ss_size = sizeof alternate_signal_stack;
+ # if SIGALTSTACK_SS_REVERSED
+   /* Irix mistakenly treats ss_sp as the upper bound, rather than
+      lower bound, of the alternate stack.  */
+-  st.ss_sp = alternate_signal_stack.buffer + SIGSTKSZ - sizeof (void *);
+-  st.ss_size = sizeof alternate_signal_stack.buffer - sizeof (void *);
+-# else
+-  st.ss_sp = alternate_signal_stack.buffer;
+-  st.ss_size = sizeof alternate_signal_stack.buffer;
++  st.ss_size -= sizeof (void *);
++  char *ss_sp = st.ss_sp;
++  st.ss_sp = ss_sp + st.ss_size;
+ # endif
+   r = sigaltstack (&st, NULL);
+   if (r != 0)
+diff --git lib/c-stack.h lib/c-stack.h
+index 36dd4ec3e..cc80bb42b 100644
+--- lib/c-stack.h
++++ lib/c-stack.h
+@@ -34,7 +34,7 @@
+    A null ACTION acts like an action that does nothing.
+ 
+    ACTION must be async-signal-safe.  ACTION together with its callees
+-   must not require more than SIGSTKSZ bytes of stack space.  Also,
++   must not require more than 64 KiB of stack space.  Also,
+    ACTION should not call longjmp, because this implementation does
+    not guarantee that it is safe to return to the original stack.
+ 
+-- 
+2.35.1
+


### PR DESCRIPTION
The following error occurred on systems with glibc 2.34+:

```
external/org_gnu_gnulib/lib/c-stack.c:55:26: error: function-like macro 'sysconf' is not defined
                         ^
/usr/include/bits/sigstksz.h:28:19: note: expanded from macro 'SIGSTKSZ'
                  ^
external/org_gnu_gnulib/lib/c-stack.c:141:8: error: fields must have a constant size: 'variable length array in structure' extension will never be supported
  char buffer[SIGSTKSZ];
```

It turns out "MINSIGSTKSZ and SIGSTKSZ are no longer constant on
Linux, MINSIGSTKSZ is redefined to sysconf(_SC_MINSIGSTKSZ) and
SIGSTKSZ is redefined to sysconf (_SC_SIGSTKSZ)" [1].

This creates an issue for cases where constant value is expected, but
luckily, upstream already has a patch (coreutils/gnulib@f9e2b20a12).

This change backports the patch to our version of gnulib.

\[1]: https://sourceware.org/pipermail/libc-alpha/2021-August/129718.html