### PR TITLE
Adds support for the OSX-default Clang.

### DIFF
--- a/dependency_support/com_icarus_iverilog/bundled.BUILD.bazel
+++ b/dependency_support/com_icarus_iverilog/bundled.BUILD.bazel
@@ -372,9 +372,11 @@ cc_binary(
     linkopts = [
         "-ldl",
         "-Wl,-u," + ",-u,".join(ivl_def),
-        "-Wl,--export-dynamic",
         "-Wl,-no-pie",
-    ],
+    ] + select({
+        "@bazel_tools//src/conditions:darwin": ["-Wl,-export_dynamic"],
+        "//conditions:default": ["-Wl,--export-dynamic"],
+    }),
     deps = [
         "ivl-misc",
         ":shared_headers",
@@ -529,8 +531,10 @@ cc_binary(
     linkopts = [
         "-ldl",
         "-Wl,-u," + ",-u,".join(vvp_def),
-        "-Wl,--export-dynamic",
-    ],
+    ] + select({
+        "@bazel_tools//src/conditions:darwin": ["-Wl,-export_dynamic"],
+        "//conditions:default": ["-Wl,--export-dynamic"],
+    }),
     deps = [
         ":shared_headers",
         ":vpi_user",


### PR DESCRIPTION
Adds a Bazel `select` for Darwin to specify the OSX-default definition
of the "--export-dynamic/-export_dynamic" linker flag.

Encountered while building iverilog on an M1 Mac. Tested in that environment, but not in Linux and/or on x86.