### PR TITLE
upgrade abseil to latest LTS

### DIFF
--- a/dependency_support/com_google_absl/com_google_absl.bzl
+++ b/dependency_support/com_google_absl/com_google_absl.bzl
@@ -21,7 +21,7 @@ def com_google_absl():
     maybe(
         http_archive,
         name = "com_google_absl",
-        strip_prefix = "abseil-cpp-20210324.2",
-        urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20210324.2.zip"],
-        sha256 = "1a7edda1ff56967e33bc938a4f0a68bb9efc6ba73d62bb4a5f5662463698056c",
+        strip_prefix = "abseil-cpp-20211102.0",
+        urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20211102.0.zip"],
+        sha256 = "a4567ff02faca671b95e31d315bab18b42b6c6f1a60e91c6ea84e5a2142112c2",
     )


### PR DESCRIPTION
There are compile warnings for older abseil versions in OSX (clang)