### PR TITLE
clang and gcc

### DIFF
--- a/dependency_support/org_theopenroadproject/bundled.BUILD.bazel
+++ b/dependency_support/org_theopenroadproject/bundled.BUILD.bazel
@@ -115,8 +115,8 @@ cc_binary(
         "-Wcast-qual",
         "-Wredundant-decls",
         "-Wformat-security",
+        "-fopenmp",
         "-std=c++17",
-        "-fopenmp"
     ],
     features = ["-use_header_modules"],
     visibility = ["//visibility:public"],
@@ -308,6 +308,7 @@ cc_library(
         "-Wredundant-decls",
         "-Wformat-security",
         "-Iexternal/com_github_quantamhd_lemon",
+        "-std=c++17",
     ],
     features = ["-use_header_modules"],
     includes = [
@@ -457,6 +458,7 @@ cc_library(
         "-Wcast-qual",
         "-Wredundant-decls",
         "-Wformat-security",
+        "-std=c++17",
     ],
     includes = [
         "src/utl/include",
@@ -1214,6 +1216,7 @@ cc_library(
     copts = [
         "-fexceptions",
         "-Wno-error",
+        "-std=c++17",
     ],
     features = ["-use_header_modules"],
     includes = [
@@ -1259,6 +1262,7 @@ cc_library(
     copts = [
         "-fexceptions",
         "-Wno-error",
+        "-std=c++17",
     ],
     features = ["-use_header_modules"],
     includes = [

--- a/dependency_support/org_theopenroadproject/bundled.BUILD.bazel
+++ b/dependency_support/org_theopenroadproject/bundled.BUILD.bazel
@@ -411,7 +411,7 @@ cc_library(
         "@com_github_quantamhd_lemon//:lemon",
         "@com_github_gabime_spdlog//:spdlog",
         "@tk_tcl//:tcl",
-        "@org_llvm_openmp//:openmp",
+        #"@org_llvm_openmp//:openmp",
     ],
     alwayslink = True,
 )

--- a/dependency_support/org_theopenroadproject/bundled.BUILD.bazel
+++ b/dependency_support/org_theopenroadproject/bundled.BUILD.bazel
@@ -118,6 +118,9 @@ cc_binary(
         "-fopenmp",
         "-std=c++17",
     ],
+    linkopts = [
+        "-fopenmp",
+    ],
     features = ["-use_header_modules"],
     visibility = ["//visibility:public"],
     deps = [

--- a/dependency_support/org_theopenroadproject/bundled.BUILD.bazel
+++ b/dependency_support/org_theopenroadproject/bundled.BUILD.bazel
@@ -486,6 +486,7 @@ cc_library(
         "-Wcast-qual",
         "-Wredundant-decls",
         "-Wformat-security",
+        "-std=c++17",
     ],
     features = ["-use_header_modules"],
     includes = [

--- a/dependency_support/org_theopenroadproject/bundled.BUILD.bazel
+++ b/dependency_support/org_theopenroadproject/bundled.BUILD.bazel
@@ -1149,6 +1149,7 @@ cc_library(
     copts = [
         "-fexceptions",
         "-Wno-error",
+        "-std=c++17",
     ],
     features = [
       "-use_header_modules",

--- a/dependency_support/org_theopenroadproject/bundled.BUILD.bazel
+++ b/dependency_support/org_theopenroadproject/bundled.BUILD.bazel
@@ -115,6 +115,7 @@ cc_binary(
         "-Wcast-qual",
         "-Wredundant-decls",
         "-Wformat-security",
+        "-std=c++17",
         "-fopenmp"
     ],
     features = ["-use_header_modules"],


### PR DESCRIPTION
The patch disables openmp package and uses the default in the system. Otherwise, it requires the same clang version as the openmp (which is a problem to compile with gcc).

The other part of the patch is to enable c++17 in openroad (they use this in their builds). It does not build in the latest gcc/clang otherwise.

The patch allows gcc and clang to work (I tried gcc 11 and clang 13, but others should work too). To compile with clang:

```
CXX=clang++ CC=clang bazel build ....
```

I create a small repo to test this (it points to renau/bazel_rules_hdl not the hdl/bazel_rules_hdl)