### PR TITLE
Bump Yosys to 0.22, incl version string and patch.

### DIFF
--- a/dependency_support/at_clifford_yosys/at_clifford_yosys.bzl
+++ b/dependency_support/at_clifford_yosys/at_clifford_yosys.bzl
@@ -22,10 +22,10 @@ def at_clifford_yosys():
         http_archive,
         name = "at_clifford_yosys",
         urls = [
-            "https://github.com/YosysHQ/yosys/archive/refs/tags/yosys-0.13.zip",
+            "https://github.com/YosysHQ/yosys/archive/refs/tags/yosys-0.22.zip",
         ],
-        sha256 = "8dcebc0257b4ef30916fbaacbe938c1f1dc20315bd7c97342048a8ee8a950215",
-        strip_prefix = "yosys-yosys-0.13",
+        sha256 = "450fe6c462351bc3b245683183964551ed4c0437a35d55138d8a9668aa954578",
+        strip_prefix = "yosys-yosys-0.22",
         build_file = Label("@rules_hdl//dependency_support:at_clifford_yosys/bundled.BUILD.bazel"),
         patches = [
             Label("@rules_hdl//dependency_support:at_clifford_yosys/yosys.patch"),

--- a/dependency_support/at_clifford_yosys/bundled.BUILD.bazel
+++ b/dependency_support/at_clifford_yosys/bundled.BUILD.bazel
@@ -448,6 +448,9 @@ cc_library(
         "libs/fst/fstapi.h",
         "libs/fst/lz4.h",
     ],
+    deps = [
+        "@net_zlib//:zlib",
+    ],
     licenses = ["notice"],
 )
 

--- a/dependency_support/at_clifford_yosys/bundled.BUILD.bazel
+++ b/dependency_support/at_clifford_yosys/bundled.BUILD.bazel
@@ -31,7 +31,7 @@ exports_files(["LICENSE"])
 genrule(
     name = "version_src",
     outs = ["kernel/version.cc"],
-    cmd = "echo 'namespace Yosys { extern const char *yosys_version_str; const char *yosys_version_str=\"Yosys 0.8+\"; }' >$@",
+    cmd = "echo 'namespace Yosys { extern const char *yosys_version_str; const char *yosys_version_str=\"Yosys 0.22\"; }' >$@",
 )
 
 cc_library(

--- a/dependency_support/at_clifford_yosys/bundled.BUILD.bazel
+++ b/dependency_support/at_clifford_yosys/bundled.BUILD.bazel
@@ -204,6 +204,7 @@ cc_library(
         ":minisat",
         ":sha1",
         ":subcircuit",
+        ":fst",
         "@org_gnu_readline//:readline",
         "@edu_berkeley_abc//:abc-lib",
         "@org_sourceware_libffi//:libffi",
@@ -431,6 +432,22 @@ cc_library(
         "libs/subcircuit/subcircuit.cc",
     ],
     hdrs = ["libs/subcircuit/subcircuit.h"],
+    licenses = ["notice"],
+)
+
+cc_library(
+    name = "fst",
+    srcs = [
+        "libs/fst/fastlz.cc",
+        "libs/fst/fstapi.cc",
+        "libs/fst/lz4.cc",
+    ],
+    hdrs = [
+        "libs/fst/config.h",
+        "libs/fst/fastlz.h",
+        "libs/fst/fstapi.h",
+        "libs/fst/lz4.h",
+    ],
     licenses = ["notice"],
 )
 

--- a/dependency_support/at_clifford_yosys/yosys.patch
+++ b/dependency_support/at_clifford_yosys/yosys.patch
@@ -1,6 +1,6 @@
 --- kernel/yosys.cc
 +++ kernel/yosys.cc
-@@ -863,13 +863,12 @@ void init_share_dirname()
+@@ -930,13 +930,12 @@ void init_share_dirname()
  		yosys_share_dirname = proc_share_path;
  		return;
  	}


### PR DESCRIPTION
Signed-off-by: Tim Callahan <tcal@google.com>