### PR TITLE
Fixes redacted version info in bison and m4

### DIFF
--- a/dependency_support/copy.bzl
+++ b/dependency_support/copy.bzl
@@ -40,6 +40,6 @@ def touch(name, out, contents = None):
     native.genrule(
         name = name,
         outs = [out],
-        cmd = "echo " + repr(contents) + " > $@",
+        cmd = "echo -e " + repr(contents) + " > $@",
         message = "Touch $@",
     )

--- a/dependency_support/org_gnu_bison/bundled.BUILD.bazel
+++ b/dependency_support/org_gnu_bison/bundled.BUILD.bazel
@@ -88,6 +88,15 @@ touch(
     ),
 )
 
+touch(
+    name = "bazel_version_info",
+    out = "bison-lib/bazel_version_info.h",
+    contents = dict(
+        PACKAGE_VERSION = '"3.5"',
+        VERSION = '"3.5"',
+    )
+)
+
 # Note: This target is used by the Bazel "genyacc" rule, as well as by the
 # explictly-declared dependencies.
 cc_binary(
@@ -98,6 +107,7 @@ cc_binary(
         "bison-lib/get-errno.h",
         "bison-lib/path-join.c",
         "bison-lib/path-join.h",
+        "bison-lib/bazel_version_info.h",
         "src/AnnotationList.c",
         "src/InadequacyList.c",
         "src/Sbitset.c",
@@ -151,6 +161,7 @@ cc_binary(
         # This is defined in gnulib's stdio.h, but we don't need anything else
         # from that file.
         "-D_GL_ATTRIBUTE_FORMAT_PRINTF(A,B)=",
+        "-DBAZEL_VERSION_INFO",
     ],
     data = [":bison_runtime_data"],
     output_licenses = ["unencumbered"],

--- a/dependency_support/org_gnu_gnulib/org_gnu_gnulib.bzl
+++ b/dependency_support/org_gnu_gnulib/org_gnu_gnulib.bzl
@@ -8,6 +8,13 @@ _CONFIG_HEADER = """
 #include "lib/config.in.h"
 #include "lib/arg-nonnull.h"
 
+#ifdef BAZEL_VERSION_INFO
+#include "bazel_version_info.h"
+#else
+#define PACKAGE_VERSION "redacted"
+#define VERSION "redacted"
+#endif
+
 #define PRODUCT "redacted"
 #define PACKAGE "redacted"
 #define PACKAGE_BUGREPORT "redacted"
@@ -16,8 +23,7 @@ _CONFIG_HEADER = """
 #define PACKAGE_STRING "redacted"
 #define PACKAGE_TARNAME "redacted"
 #define PACKAGE_URL "redacted"
-#define PACKAGE_VERSION "redacted"
-#define VERSION "redacted"
+
 
 #define RENAME_OPEN_FILE_WORKS 0
 #define HAVE_TMPFILE 1

--- a/dependency_support/org_gnu_m4/bundled.BUILD.bazel
+++ b/dependency_support/org_gnu_m4/bundled.BUILD.bazel
@@ -15,6 +15,8 @@
 """ A BUILD file for m4 based on FSF stock source. """
 
 load("@rules_cc//cc:defs.bzl", "cc_binary")
+load("@rules_hdl//dependency_support:copy.bzl", "touch")
+
 
 package(
     default_visibility = ["//visibility:public"],
@@ -28,14 +30,30 @@ licenses(["restricted"])  # GPLv3
 
 exports_files(["COPYING"])
 
+touch(
+    name = "bazel_version_info",
+    out = "src/bazel_version_info.h",
+    contents = dict(
+        PACKAGE_VERSION = '"1.4.18"',
+        VERSION = '"1.4.18"',
+    )
+)
+
+
 cc_binary(
     name = "m4",
-    srcs = glob(["src/*.c", "src/*.h"]),
+    srcs = glob(["src/*.c", "src/*.h"]) + [
+        "src/bazel_version_info.h"
+    ],
     deps = [
         "@org_gnu_gnulib//:gnulib",
+    ],
+    includes = [
+        "src/",
     ],
     output_licenses = ["unencumbered"],
     copts = [
         "-w",
+        "-DBAZEL_VERSION_INFO",
     ],
 )


### PR DESCRIPTION
This was caused by a weird configuration for config.h in the gnulib package. I added configurability to the version information so that it gives downstream packages the option to override the redacted option.