### PR TITLE
Synthesis: Adds new synthesis_binary rule

### DIFF
--- a/place_and_route/open_road.bzl
+++ b/place_and_route/open_road.bzl
@@ -107,12 +107,21 @@ def clock_commands(ctx):
     Returns:
         Struct with params inputs and commands. Both return values are lists.
     """
-    if not clock_commands:
-        return struct(inputs = [], commands = ["create_clock [get_ports clk] -period {period}".format(period = ctx.attr.clock_period)])
-
     sdc = ctx.file.sdc
+
     if sdc:
         return struct(inputs = [sdc], commands = ["read_sdc {}".format(sdc.path)])
+
+    # If no name is passed, the clock is assumed to be named "clk".
+    if ctx.attr.clock_period:
+        return struct(
+            inputs = [],
+            commands = [
+                "create_clock [get_ports clk] -period {period}".format(
+                    period = ctx.attr.clock_period,
+                ),
+            ],
+        )
 
     return struct(
         inputs = [],


### PR DESCRIPTION
Synthesis: Adds new synthesis_binary rule

The new rules allows you to get a binary version of the synthesize_rtl rule.
This version is self contained, and can be run outside the context of bazel
