### PR TITLE
Rules to run opensta to get longest path.

### DIFF
--- a/static_timing/build_defs.bzl
+++ b/static_timing/build_defs.bzl
@@ -1,0 +1,95 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Rules for running openSTA on synthesized Verilog."""
+
+load("//synthesis:build_defs.bzl", "SynthesisInfo")
+
+def _run_opensta_impl(ctx):
+    """Implementation of the 'run_opensta' rule.
+
+    Runs opensta on a synthesized netlist.
+
+    Args:
+      ctx: The current rule's context object.
+    Returns:
+      DefaultInfo provider
+    """
+    synth_info = ctx.attr.synth_target[SynthesisInfo]
+
+    netlist = synth_info.synthesized_netlist
+    liberty_file = synth_info.standard_cell_info.default_corner.liberty
+
+    (tool_inputs, input_manifests) = ctx.resolve_tools(tools = [ctx.attr._opensta])
+    sta_tcl = ctx.file.sta_tcl
+    sta_log = ctx.actions.declare_file("sta.log")
+
+    env = {
+        "NETLIST": netlist.path,
+        "TOP": synth_info.top_module,
+        "LOGFILE": sta_log.path,
+        "LIBERTY": liberty_file.path,
+    }
+
+    ctx.actions.run(
+        outputs = [sta_log],
+        inputs = tool_inputs.to_list() + [liberty_file, sta_tcl, netlist],
+        arguments = ["-exit", sta_tcl.path],
+        executable = ctx.executable._opensta,
+        tools = tool_inputs,
+        input_manifests = input_manifests,
+        env = env,
+        mnemonic = "RunningSTA",
+    )
+
+    return [
+        DefaultInfo(
+            files = depset(
+                direct = [sta_log],
+                transitive = [],
+            ),
+        ),
+    ]
+
+run_opensta_attrs = {
+    "synth_target": attr.label(
+        doc = "The synth target to benchmark.",
+        providers = [SynthesisInfo, DefaultInfo],
+    ),
+    "sta_tcl": attr.label(
+        default = Label("//static_timing:sta.tcl"),
+        allow_single_file = True,
+        doc = "Tcl opensta script compatible with the environment-variable API of sta.tcl",
+    ),
+    "_opensta": attr.label(
+        default = Label("@org_theopenroadproject//:opensta"),
+        executable = True,
+        cfg = "exec",
+    ),
+}
+
+run_opensta = rule(
+    doc = """Find longest path in a synthesized netlist using openSTA.
+
+Example:
+    ```
+    run_opensta(
+        name = "picorv32_benchmark_sta",
+        synth_target = ":picorv32_synth",
+    )
+    ```
+    """,
+    implementation = _run_opensta_impl,
+    attrs = run_opensta_attrs,
+)

--- a/static_timing/sta.tcl
+++ b/static_timing/sta.tcl
@@ -1,0 +1,26 @@
+# Default openSTA timing tcl script for the run_opensta rule.
+# It can be replaced by a user-defined script by overriding the sta_tcl
+# argument of that rule.
+
+# User-defined timing scripts need to consult the following environment
+# variables for their parameters:
+# NETLIST = synthesized netlist (Verilog)
+# TOP = top module in NETLIST
+# LIBERTY = liberty file for the target technology library
+# LOGFILE = file for analysis output
+
+
+set sta_log $::env(LOGFILE)
+set netlist $::env(NETLIST)
+set liberty $::env(LIBERTY)
+set top $::env(TOP)
+
+redirect_file_begin $sta_log
+read_verilog $netlist
+read_liberty $liberty
+link_design  $top
+report_checks -unconstrained
+redirect_file_end
+
+# also output to stdout
+report_checks -unconstrained

--- a/synthesis/build_defs.bzl
+++ b/synthesis/build_defs.bzl
@@ -83,7 +83,10 @@ def _synthesize_design_impl(ctx):
         files = uhdm_files,
     )
 
-    output_file = ctx.actions.declare_file("{}_synth_output.v".format(ctx.attr.name))
+    output_file_name = "{}_synth_output.v".format(ctx.attr.name)
+    if ctx.attr.output_file_name:
+        output_file_name = ctx.attr.output_file_name
+    output_file = ctx.actions.declare_file(output_file_name)
     default_liberty_file = ctx.attr.standard_cells[StandardCellInfo].default_corner.liberty
 
     synth_tcl = ctx.file.synth_tcl
@@ -243,6 +246,7 @@ synthesize_rtl = rule(
             doc = "Tcl synthesis script compatible with the environment-variable API of synth.tcl",
         ),
         "target_clock_period_pico_seconds": attr.int(doc = "target clock period in picoseconds"),
+        "output_file_name": attr.string(doc = "The output file name."),
     },
 )
 


### PR DESCRIPTION
Rules to run opensta to get longest path.

Uses a default "sta.tcl" script that can be overridden.
