### PR TITLE
Rules to run opensta to get longest path.

### DIFF
--- a/dependency_support/org_theopenroadproject/bundled.BUILD.bazel
+++ b/dependency_support/org_theopenroadproject/bundled.BUILD.bazel
@@ -1518,6 +1518,7 @@ cc_binary(
         ":opensta_lib",
         "@tk_tcl//:tcl",
     ],
+    visibility = ["//visibility:public"],
 )
 
 cc_library(

--- a/static_timing/BUILD
+++ b/static_timing/BUILD
@@ -1,0 +1,17 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Static timing tool package.
+
+exports_files(["sta.tcl"])

--- a/static_timing/build_defs.bzl
+++ b/static_timing/build_defs.bzl
@@ -35,7 +35,7 @@ def _run_opensta_impl(ctx):
     opensta_runfiles_dir = ctx.executable._opensta.path + ".runfiles"
 
     sta_tcl = ctx.file.sta_tcl
-    sta_log = ctx.actions.declare_file("sta.log")
+    sta_log = ctx.actions.declare_file("{}_sta.log".format(ctx.attr.name))
 
     env = {
         "NETLIST": netlist.path,

--- a/static_timing/build_defs.bzl
+++ b/static_timing/build_defs.bzl
@@ -68,7 +68,7 @@ def _run_opensta_impl(ctx):
 run_opensta_attrs = {
     "synth_target": attr.label(
         doc = "The synth target to benchmark.",
-        providers = [SynthesisInfo, DefaultInfo],
+        providers = [SynthesisInfo],
     ),
     "sta_tcl": attr.label(
         default = Label("//static_timing:sta.tcl"),

--- a/static_timing/build_defs.bzl
+++ b/static_timing/build_defs.bzl
@@ -32,6 +32,8 @@ def _run_opensta_impl(ctx):
     liberty_file = synth_info.standard_cell_info.default_corner.liberty
 
     (tool_inputs, input_manifests) = ctx.resolve_tools(tools = [ctx.attr._opensta])
+    opensta_runfiles_dir = ctx.executable._opensta.path + ".runfiles"
+
     sta_tcl = ctx.file.sta_tcl
     sta_log = ctx.actions.declare_file("sta.log")
 
@@ -40,6 +42,7 @@ def _run_opensta_impl(ctx):
         "TOP": synth_info.top_module,
         "LOGFILE": sta_log.path,
         "LIBERTY": liberty_file.path,
+        "TCL_LIBRARY": opensta_runfiles_dir + "/tk_tcl/library",
     }
 
     ctx.actions.run(

--- a/static_timing/build_defs.bzl
+++ b/static_timing/build_defs.bzl
@@ -1,0 +1,95 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Rules for running openSTA on synthesized Verilog."""
+
+load("//synthesis:build_defs.bzl", "SynthesisInfo")
+
+def _run_opensta_impl(ctx):
+    """Implementation of the 'run_opensta' rule.
+
+    Runs opensta on a synthesized netlist.
+
+    Args:
+      ctx: The current rule's context object.
+    Returns:
+      DefaultInfo provider
+    """
+    synth_info = ctx.attr.synth_target[SynthesisInfo]
+
+    netlist = synth_info.synthesized_netlist
+    liberty_file = synth_info.standard_cell_info.default_corner.liberty
+
+    (tool_inputs, input_manifests) = ctx.resolve_tools(tools = [ctx.attr._opensta])
+    sta_tcl = ctx.file.sta_tcl
+    sta_log = ctx.actions.declare_file("sta.log")
+
+    env = {
+        "NETLIST": netlist.path,
+        "TOP": synth_info.top_module,
+        "LOGFILE": sta_log.path,
+        "LIBERTY": liberty_file.path,
+    }
+
+    ctx.actions.run(
+        outputs = [sta_log],
+        inputs = tool_inputs.to_list() + [liberty_file, sta_tcl, netlist],
+        arguments = ["-exit", sta_tcl.path],
+        executable = ctx.executable._opensta,
+        tools = tool_inputs,
+        input_manifests = input_manifests,
+        env = env,
+        mnemonic = "RunningSTA",
+    )
+
+    return [
+        DefaultInfo(
+            files = depset(
+                direct = [sta_log],
+                transitive = [],
+            ),
+        ),
+    ]
+
+run_opensta_attrs = {
+    "synth_target": attr.label(
+        doc = "The synth target to benchmark.",
+        providers = [SynthesisInfo, DefaultInfo],
+    ),
+    "sta_tcl": attr.label(
+        default = Label("//static_timing:sta.tcl"),
+        allow_single_file = True,
+        doc = "Tcl opensta script compatible with the environment-variable API of sta.tcl",
+    ),
+    "_opensta": attr.label(
+        default = Label("@org_theopenroadproject//:opensta"),
+        executable = True,
+        cfg = "exec",
+    ),
+}
+
+run_opensta = rule(
+    doc = """Find longest path in a synthesized netlist using openSTA.
+
+Example:
+    ```
+    run_opensta(
+        name = "picorv32_benchmark_sta",
+        synth_target = ":picorv32_synth",
+    )
+    ```
+    """,
+    implementation = _run_opensta_impl,
+    attrs = run_opensta_attrs,
+)

--- a/static_timing/sta.tcl
+++ b/static_timing/sta.tcl
@@ -1,0 +1,26 @@
+# Default openSTA timing tcl script for the run_opensta rule.
+# It can be replaced by a user-defined script by overriding the sta_tcl
+# argument of that rule.
+
+# User-defined timing scripts need to consult the following environment
+# variables for their parameters:
+# NETLIST = synthesized netlist (Verilog)
+# TOP = top module in NETLIST
+# LIBERTY = liberty file for the target technology library
+# LOGFILE = file for analysis output
+
+
+set sta_log $::env(LOGFILE)
+set netlist $::env(NETLIST)
+set liberty $::env(LIBERTY)
+set top $::env(TOP)
+
+redirect_file_begin $sta_log
+read_verilog $netlist
+read_liberty $liberty
+link_design  $top
+report_checks -unconstrained
+redirect_file_end
+
+# also output to stdout
+report_checks -unconstrained

--- a/synthesis/tests/BUILD
+++ b/synthesis/tests/BUILD
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 load("//synthesis:build_defs.bzl", "synthesize_rtl")
+load("//static_timing:build_defs.bzl", "run_opensta")
 load("//place_and_route:build_defs.bzl", "place_and_route")
 load("//verilog:providers.bzl", "verilog_library")
 
@@ -41,12 +42,22 @@ place_and_route(
     synthesized_rtl = ":verilog_counter_synth",
 )
 
+run_opensta(
+    name = "verilog_counter_synth_sta",
+    synth_target = ":verilog_counter_synth",
+)
+
 synthesize_rtl(
     name = "verilog_counter_synth",
     top_module = "counter",
     deps = [
         ":verilog_counter",
     ],
+)
+
+run_opensta(
+    name = "verilog_counter_asap7_synth_sta",
+    synth_target = ":verilog_counter_asap7_synth",
 )
 
 synthesize_rtl(


### PR DESCRIPTION
Rules to run opensta to get longest path.

Uses a default "sta.tcl" script that can be overridden.
