### PR TITLE
Don't hardcode assumed path to /bin/bash, use /usr/bin/env bash instead.

### DIFF
--- a/dependency_support/com_icarus_iverilog/dummy.sh
+++ b/dependency_support/com_icarus_iverilog/dummy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Google LLC
 #

--- a/dependency_support/com_icarus_iverilog/hello_verilog_test.sh
+++ b/dependency_support/com_icarus_iverilog/hello_verilog_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 The XLS Authors
 #

--- a/dependency_support/com_icarus_iverilog/iverilog.sh
+++ b/dependency_support/com_icarus_iverilog/iverilog.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/dependency_support/com_icarus_iverilog/vvp.sh
+++ b/dependency_support/com_icarus_iverilog/vvp.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
In a pure environment (such as nixos), the hard-coded path /bin/bash might not exist. The recommended way in the Unix environment is to use /usr/bin/env

Signed-off-by: Henner Zeller <h.zeller@acm.org>