### PR TITLE
Bump requirements.txt

### DIFF
--- a/dependency_support/pip_requirements.txt
+++ b/dependency_support/pip_requirements.txt
@@ -1,4 +1,4 @@
-dataclasses-json==0.5.2
-jwt==1.1.0
-requests==2.25.1
-absl-py==1.0.0
+dataclasses-json==0.5.7
+jwt==1.3.1
+requests==2.28.2
+absl-py==1.4.0


### PR DESCRIPTION
JWT transitively includes cryptography, which seems not to build successfully on new-ish macs. Bumping the version seems to resolve this.