### PR TITLE
Move commands in StaApp into sta:: namespace to match behavior of external builds.

### DIFF
--- a/dependency_support/org_theopenroadproject/bundled.BUILD.bazel
+++ b/dependency_support/org_theopenroadproject/bundled.BUILD.bazel
@@ -1449,6 +1449,7 @@ tcl_wrap_cc(
     srcs = [
         ":sta_swig_files",
     ],
+    namespace_prefix = "sta",
     root_swig_src = "src/sta/app/StaApp.i",
     swig_includes = [
         "src/sta/dcalc",

--- a/static_timing/sta.tcl
+++ b/static_timing/sta.tcl
@@ -15,12 +15,12 @@ set netlist $::env(NETLIST)
 set liberty $::env(LIBERTY)
 set top $::env(TOP)
 
-redirect_file_begin $sta_log
+sta::redirect_file_begin $sta_log
 read_verilog $netlist
 read_liberty $liberty
 link_design  $top
 report_checks -unconstrained
-redirect_file_end
+sta::redirect_file_end
 
 # also output to stdout
 report_checks -unconstrained

--- a/synthesis/synth.tcl
+++ b/synthesis/synth.tcl
@@ -39,6 +39,13 @@ foreach src $srcs {
 
 # generic synthesis
 set top $::env(TOP)
+hierarchy -check -top $top
+# Move proc_mux at the end of `yosys proc` to avoid inferred latches.
+# See https://github.com/YosysHQ/yosys/issues/3456
+# Ideally the bug would be solved in UHDM/Yosys.
+yosys proc -nomux
+yosys proc_mux
+yosys flatten
 yosys synth -top $top
 
 # mapping to liberty


### PR DESCRIPTION
Move commands in StaApp into sta:: namespace to match behavior of external builds.
