### PR TITLE
org_llvm_openmp: Add omp-tools.h to bundled.BUILD.bazel

### DIFF
--- a/dependency_support/org_llvm_openmp/bundled.BUILD.bazel
+++ b/dependency_support/org_llvm_openmp/bundled.BUILD.bazel
@@ -14,7 +14,10 @@
 
 cc_library(
     name = "openmp",
-    hdrs = ["runtime/src/include/omp.h"],
+    hdrs = [
+      "runtime/src/include/omp.h",
+      "runtime/src/include/omp-tools.h",
+    ],
     srcs = [
       "runtime/src/kmp.h",
       "runtime/src/kmp_alloc.cpp",
@@ -112,6 +115,19 @@ genrule(
       "-e 's/@LIBOMP_VERSION_BUILD@/0/g' " +
       "-e 's/@LIBOMP_BUILD_DATE@/20200907/g' " +
       "$(location runtime/src/include/omp.h.var) " +
+      "> $@"
+    )
+)
+
+genrule(
+    name = "omp_tools_header",
+    srcs = [
+        "runtime/src/include/omp-tools.h.var",
+    ],
+    outs = ["runtime/src/include/omp-tools.h"],
+    cmd = (
+      "cat " +
+      "$(location runtime/src/include/omp-tools.h.var) " +
       "> $@"
     )
 )


### PR DESCRIPTION
This PR fixes `org_llvm_openmp` build failures I encountered while trying to run target based on rule `place_and_route`. 

`BUILD` file for `openmp` didn't specify `omp-tools.h` as its dependency. This header is present in the codebase as `omp-tools.h.var` and it is renamed to required `omp-tools.h` by the [cmake flow](https://github.com/llvm/llvm-project/blob/main/openmp/runtime/src/CMakeLists.txt#L17). In order to fix this in bazel rules I added `genrule` for copying the file and specified the missing dependency.