### PR TITLE
dependency_support: boost: bump boost to v1.82

### DIFF
--- a/dependency_support/boost/add_python.patch
+++ b/dependency_support/boost/add_python.patch
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-diff --git BUILD.boost BUILD.boost
-index e6b28cf..99470c5 100644
---- BUILD.boost
-+++ BUILD.boost
-@@ -2268,3 +2268,41 @@ boost_library(
-         ":utility",
+diff --git boost.BUILD boost.BUILD
+index e5d0b60..4f52d3c 100644
+--- boost.BUILD
++++ boost.BUILD
+@@ -2642,3 +2642,44 @@ boost_library(
+         ":variant2",
      ],
  )
 +
@@ -27,6 +27,9 @@ index e6b28cf..99470c5 100644
 +        "libs/python/src/converter/*.cpp",
 +        "libs/python/src/object/*.cpp",
 +    ]),
++    exclude_src = [
++        "libs/python/src/fabscript",
++    ],
 +    deps = [
 +        ":assert",
 +        ":bind",

--- a/dependency_support/boost/boost.bzl
+++ b/dependency_support/boost/boost.bzl
@@ -21,8 +21,8 @@ def boost():
     maybe(
         git_repository,
         name = "com_github_nelhage_rules_boost",
-        # This equivalent to boost 1.78
-        commit = "c8b9b4a75c4301778d2e256b8d72ce47a6c9a1a4",
+        # This equivalent to boost 1.82
+        commit = "1217caae292dc9f14e8109777ba43c988cf89c5b",
         remote = "https://github.com/nelhage/rules_boost",
         shallow_since = "1640124117 -0800",
         patches = [

--- a/dependency_support/boost/libbacktrace.patch
+++ b/dependency_support/boost/libbacktrace.patch
@@ -1,9 +1,9 @@
-diff --git BUILD.boost BUILD.boost
-index e23893b..1e70e11 100644
---- BUILD.boost
-+++ BUILD.boost
-@@ -1874,6 +1874,7 @@ boost_library(
-         ":lexical_cast",
+diff --git boost.BUILD boost.BUILD
+index e5d0b60..bade47f 100644
+--- boost.BUILD
++++ boost.BUILD
+@@ -1927,6 +1927,7 @@ boost_library(
+         ":predef",
          ":static_assert",
          ":type_traits",
 +        "@com_github_libbacktrace//:libbacktrace",

--- a/dependency_support/com_github_gabime_spdlog/com_github_gabime_spdlog.bzl
+++ b/dependency_support/com_github_gabime_spdlog/com_github_gabime_spdlog.bzl
@@ -22,9 +22,9 @@ def com_github_gabime_spdlog():
         http_archive,
         name = "com_github_gabime_spdlog",
         urls = [
-            "https://github.com/gabime/spdlog/archive/refs/tags/v1.9.2.tar.gz",
+            "https://github.com/gabime/spdlog/archive/refs/tags/v1.11.0.tar.gz",
         ],
-        strip_prefix = "spdlog-1.9.2",
-        sha256 = "6fff9215f5cb81760be4cc16d033526d1080427d236e86d70bb02994f85e3d38",
+        strip_prefix = "spdlog-1.11.0",
+        sha256 = "ca5cae8d6cac15dae0ec63b21d6ad3530070650f68076f3a4a862ca293a858bb",
         build_file = Label("@rules_hdl//dependency_support/com_github_gabime_spdlog:bundled.BUILD.bazel"),
     )


### PR DESCRIPTION
This PR is the second one in the PR chain that consists of:
* [1/3] https://github.com/hdl/bazel_rules_hdl/pull/167
* [2/3] https://github.com/hdl/bazel_rules_hdl/pull/164
* [3/3] https://github.com/hdl/bazel_rules_hdl/pull/165

Each of the following PRs depend on previous ones which means that the correct merging order is: 
https://github.com/hdl/bazel_rules_hdl/pull/167 -> https://github.com/hdl/bazel_rules_hdl/pull/164 -> https://github.com/hdl/bazel_rules_hdl/pull/165
I will rebase the PRs one at the time as they are merged in order to avoid conflicts.

This PR bumps the build rules for boost effectively bumping boost dependency to v1.82.
Due to rename (BUILD.boost -> boost.BUILD) and small changes in the renamed file also the patches had to be updated.
Additionally, `boost_library` for `boost/python` adds to `cc_library` sources all files under `libs/python/src` which includes `fabscript` which is not a C++ source and that is causing build failures. I had to further modify `add_python.patch` to explicitly remove this file from the build configuration.

Bumping boost was required to make `openroad` target working as I kept getting build errors:
```
ERROR: /home/asdf/.cache/bazel/asdf/970c5c2433bb6038ab152477a024c421/external/boost/BUILD.bazel:1750:14: Compiling libs/thread/src/pthread/thread.cpp failed: (Exit 1): gcc failed: error executing command /usr/bin/gcc -U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer -g0 -O2 '-D_FORTIFY_SOURCE=1' -DNDEBUG -ffunction-sections ... (remaining 312 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox
In file included from /usr/include/pthread.h:33,
                 from /usr/include/x86_64-linux-gnu/c++/11/bits/gthr-default.h:35,
                 from /usr/include/x86_64-linux-gnu/c++/11/bits/gthr.h:148,
                 from /usr/include/c++/11/ext/atomicity.h:35,
                 from /usr/include/c++/11/bits/basic_string.h:39,
                 from /usr/include/c++/11/string:55,
                 from external/boost/boost/thread/exceptions.hpp:20,
                 from external/boost/boost/thread/pthread/thread_data.hpp:10,
                 from external/boost/boost/thread/thread_only.hpp:17,
                 from external/boost/libs/thread/src/pthread/thread.cpp:11:
external/boost/boost/thread/pthread/thread_data.hpp:60:5: error: missing binary operator before token "("
   60 | #if PTHREAD_STACK_MIN > 0
      |     ^~~~~~~~~~~~~~~~~
Target @org_theopenroadproject//:openroad failed to build
```

Another required change was bumping `spdlog`. After bumping boost I encountered spdlog build errors in my local test setup that were caused by `MINSIGSTKSZ` no longer being a constant (as described in https://github.com/catchorg/Catch2/issues/2421 and https://github.com/gabime/spdlog/issues/2058)