### PR TITLE
Fix doubled libbacktrace dependency

### DIFF
--- a/dependency_support/boost/libbacktrace.patch
+++ b/dependency_support/boost/libbacktrace.patch
@@ -2,6 +2,23 @@ diff --git boost.BUILD boost.BUILD
 index e5d0b60..bade47f 100644
 --- boost.BUILD
 +++ boost.BUILD
+@@ -1908,13 +1908,13 @@ boost_library(
+     exclude_src = ["libs/stacktrace/src/*.cpp"],
+     linkopts = select({
+         ":linux_ppc": [
+-            "-lbacktrace -ldl",
++            "-ldl",
+         ],
+         ":linux_x86_64": [
+-            "-lbacktrace -ldl",
++            "-ldl",
+         ],
+         ":linux_aarch64": [
+-            "-lbacktrace -ldl",
++            "-ldl",
+         ],
+         "//conditions:default": [],
+     }),
 @@ -1927,6 +1927,7 @@ boost_library(
          ":predef",
          ":static_assert",


### PR DESCRIPTION
This PR is the third and the last one in PR chain that consists of:
* [1/3] https://github.com/hdl/bazel_rules_hdl/pull/167
* [2/3] https://github.com/hdl/bazel_rules_hdl/pull/164
* [3/3] https://github.com/hdl/bazel_rules_hdl/pull/165

Each of the following PRs depend on previous ones which means that the correct merging order is: 
https://github.com/hdl/bazel_rules_hdl/pull/167 -> https://github.com/hdl/bazel_rules_hdl/pull/164 -> https://github.com/hdl/bazel_rules_hdl/pull/165
I will rebase the PRs one at the time as they are merged in order to avoid conflicts.

This PR fixes https://github.com/hdl/bazel_rules_hdl/issues/161.

`libbacktrace.patch` adds explicit bazel dependency on `libbacktrace` which manifests in compilation args as:
```
-Wl,-no-whole-archive bazel-out/k8-opt-exec-2B5CBBC6/bin/external/com_github_libbacktrace/liblibbacktrace.a
```
The patch does not remove `-lbacktrace` from `linkopts` which introduces second `libbacktrace` dependency, this time for OS-installed library. PR fixes the patch by removing unnecessary linker option.

