### PR TITLE
Add a rule for testing hardware designs using Cocotb framework

### DIFF
--- a/cocotb/BUILD
+++ b/cocotb/BUILD
@@ -1,0 +1,24 @@
+# Copyright 2023 Antmicro
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_hdl_pip_deps//:requirements.bzl", "requirement")
+
+py_binary(
+    name = "cocotb_wrapper",
+    srcs = ["cocotb_wrapper.py"],
+    python_version = "PY3",
+    srcs_version = "PY3",
+    visibility = ["//visibility:public"],
+    deps = [requirement("cocotb")],
+)

--- a/cocotb/cocotb.bzl
+++ b/cocotb/cocotb.bzl
@@ -1,0 +1,265 @@
+# Copyright 2023 Antmicro
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Rules for running tests using Cocotb framework"""
+
+load("//verilog:providers.bzl", "VerilogInfo")
+load("@rules_python//python:defs.bzl", "PyInfo")
+
+def _list_to_argstring(data, argname, attr = None, operation = None):
+    result = " --{}".format(argname) if data else ""
+    for value in data:
+        elem = value if attr == None else getattr(value, attr)
+        elem = elem if operation == None else operation(elem)
+        result += " {}".format(elem)
+    return result
+
+def _dict_to_argstring(data, argname):
+    result = " --{}".format(argname) if data else ""
+    for key, value in data.items():
+        result += " {}={}".format(key, value)
+    return result
+
+def _files_to_argstring(data, argname):
+    return _list_to_argstring(data, argname, "path")
+
+def _pymodules_to_argstring(data, argname):
+    remove_py = lambda s: s.removesuffix(".py")
+    return _list_to_argstring(data, argname, "basename", remove_py)
+
+def _remove_duplicates_from_list(data):
+    result = []
+    for e in data:
+        if e not in result:
+            result.append(e)
+    return result
+
+def _collect_verilog_files(ctx):
+    transitive_srcs_list = [
+        dep
+        for dep in ctx.attr.verilog_sources
+        if VerilogInfo in dep
+    ]
+    transitive_srcs_depset = depset(
+        [],
+        transitive = [dep[VerilogInfo].dag for dep in transitive_srcs_list],
+    )
+    verilog_srcs = [
+        verilog_info_struct.srcs
+        for verilog_info_struct in transitive_srcs_depset.to_list()
+    ]
+    verilog_files = depset(
+        [src for sub_tuple in verilog_srcs for src in sub_tuple] +
+        ctx.files.verilog_sources
+    )
+    return verilog_files.to_list()
+
+def _collect_vhdl_files(ctx):
+    return ctx.files.vhdl_sources
+
+def _cocotb_test_impl(ctx):
+    # prepare arguments for the test command
+    vhdl_files = _collect_vhdl_files(ctx)
+    vhdl_sources_args = _files_to_argstring(vhdl_files, "vhdl_sources")
+
+    verilog_files = _collect_verilog_files(ctx)
+    verilog_sources_args = _files_to_argstring(verilog_files, "verilog_sources")
+
+    includes_args = _list_to_argstring(ctx.attr.includes, "includes")
+    testcase_args = _list_to_argstring(ctx.attr.testcase, "testcase")
+    build_args = _list_to_argstring(ctx.attr.build_args, "build_args")
+    gpi_interfaces_args = _list_to_argstring(ctx.attr.gpi_interfaces, "gpi_interfaces")
+    test_args = _list_to_argstring(ctx.attr.test_args, "test_args")
+    plus_args = _list_to_argstring(ctx.attr.plus_args, "plus_args")
+    extra_env_args = _list_to_argstring(ctx.attr.extra_env, "extra_env")
+
+    defines_args = _dict_to_argstring(ctx.attr.defines, "defines")
+    parameters_args = _dict_to_argstring(ctx.attr.parameters, "parameters")
+
+    verbose_args = " --verbose" if ctx.attr.verbose else ""
+    seed_args = " --seed {}".format(ctx.attr.seed) if ctx.attr.seed != "" else ""
+
+    test_module_args = _pymodules_to_argstring(ctx.files.test_module, "test_module")
+
+    # define a script and a command
+    runner_script = ctx.actions.declare_file("cocotb_runner.sh")
+
+    sim_paths = _remove_duplicates_from_list([dep.label.workspace_root for dep in ctx.attr.sim])
+    path = ":".join(["$PWD/" + str(p) for p in sim_paths])
+
+    command = (
+        "PATH={}:$PATH ".format(path) +
+        "python {}".format(ctx.executable._cocotb_wrapper.short_path) +
+        " --sim {}".format(ctx.attr.sim_name) +
+        " --hdl_library {}".format(ctx.attr.hdl_library) +
+        " --hdl_toplevel {}".format(ctx.attr.hdl_toplevel) +
+        " --hdl_toplevel_lang {}".format(ctx.attr.hdl_toplevel_lang) +
+        verilog_sources_args +
+        vhdl_sources_args +
+        includes_args +
+        testcase_args +
+        build_args +
+        gpi_interfaces_args +
+        test_args +
+        plus_args +
+        extra_env_args +
+        defines_args +
+        parameters_args +
+        verbose_args +
+        seed_args +
+        test_module_args
+    )
+
+    ctx.actions.write(output = runner_script, content = command)
+
+    # specify dependencies for the script
+    py_toolchain = ctx.toolchains["@bazel_tools//tools/python:toolchain_type"].py3_runtime
+    transitive_files = depset(
+        direct = [py_toolchain.interpreter],
+        transitive = [dep[PyInfo].transitive_sources for dep in ctx.attr.deps] +
+                     [ctx.attr._cocotb_wrapper[PyInfo].transitive_sources] +
+                     [py_toolchain.files],
+    )
+
+    runfiles = ctx.runfiles(
+        files = ctx.files._cocotb_wrapper +
+                verilog_files +
+                vhdl_files +
+                ctx.files.test_module,
+        transitive_files = transitive_files,
+    ).merge_all(
+        [dep.default_runfiles for dep in ctx.attr.deps] +
+        [dep.default_runfiles for dep in ctx.attr.test_module] +
+        [dep.default_runfiles for dep in ctx.attr.sim],
+    )
+
+    # specify pythonpath for the script
+    test_module_paths = _remove_duplicates_from_list([module.dirname for module in ctx.files.test_module])
+    pypath = ":".join([str(p) for p in test_module_paths])
+    env = {"PYTHONPATH": pypath}
+
+    # return the information about testing script and its dependencies
+    return [
+        DefaultInfo(executable = runner_script, runfiles = runfiles),
+        testing.TestEnvironment(env),
+    ]
+
+_cocotb_test_attrs = {
+    "sim": attr.label_list(
+        doc = "Simulator to use",
+        default = [
+            Label("@com_icarus_iverilog//:iverilog"),
+            Label("@com_icarus_iverilog//:vvp"),
+        ],
+    ),
+    "sim_name": attr.string(
+        doc = "Simulator name used in Cocotb",
+        default = "icarus",
+        values = ["ghdl", "icarus", "questa", "verilator", "vcs"],
+    ),
+    "hdl_library": attr.string(
+        doc = "The library name to compile into",
+        default = "top",
+    ),
+    "verilog_sources": attr.label_list(
+        doc = "Verilog source files to build",
+        providers = [VerilogInfo],
+        allow_files = True,
+        default = [],
+    ),
+    "vhdl_sources": attr.label_list(
+        doc = "VHDL source files to build",
+        allow_files = [".vhd", ".vhdl"],
+        default = [],
+    ),
+    "includes": attr.string_list(
+        doc = "Verilog include directories",
+        default = [],
+    ),
+    "defines": attr.string_dict(
+        doc = "Defines to set",
+        default = {},
+    ),
+    "parameters": attr.string_dict(
+        doc = "Verilog parameters or VHDL generics",
+        default = {},
+    ),
+    "build_args": attr.string_list(
+        doc = "Extra build arguments for the simulator",
+        default = [],
+    ),
+    "hdl_toplevel": attr.string(
+        doc = "The name of the HDL toplevel module",
+        mandatory = True,
+    ),
+    "verbose": attr.bool(
+        doc = "Enable verbose messages",
+        default = False,
+    ),
+    "test_module": attr.label_list(
+        doc = "Name(s) of the Python module(s) containing the tests to run",
+        allow_files = [".py"],
+        allow_empty = False,
+        mandatory = True,
+    ),
+    "hdl_toplevel_lang": attr.string(
+        doc = "Language of the HDL toplevel module",
+        mandatory = True,
+    ),
+    "gpi_interfaces": attr.string_list(
+        doc = "List of GPI interfaces to use, with the first one being the entry point",
+        default = [],
+    ),
+    "testcase": attr.string_list(
+        doc = "Name(s) of a specific testcase(s) to run. If not set, run all testcases found in *test_module*",
+        default = [],
+    ),
+    "seed": attr.string(
+        doc = "A specific random seed to use",
+        default = "",
+    ),
+    "test_args": attr.string_list(
+        doc = "Extra arguments for the simulator",
+        default = [],
+    ),
+    "plus_args": attr.string_list(
+        doc = "'plusargs' to set for the simulator",
+        default = [],
+    ),
+    "extra_env": attr.string_list(
+        doc = "Extra environment variables to set",
+        default = [],
+    ),
+    "waves": attr.bool(
+        doc = "Record signal traces",
+        default = True,
+    ),
+    "deps": attr.label_list(
+        doc = "The list of python libraries to be linked in to the simulation target",
+        providers = [PyInfo],
+    ),
+    "_cocotb_wrapper": attr.label(
+        cfg = "exec",
+        executable = True,
+        doc = "Cocotb wrapper script",
+        default = Label("//cocotb:cocotb_wrapper"),
+    ),
+}
+
+cocotb_test = rule(
+    implementation = _cocotb_test_impl,
+    attrs = _cocotb_test_attrs,
+    toolchains = ["@bazel_tools//tools/python:toolchain_type"],
+    test = True,
+)

--- a/cocotb/cocotb_wrapper.py
+++ b/cocotb/cocotb_wrapper.py
@@ -1,0 +1,172 @@
+# Copyright 2023 Antmicro
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+from cocotb.runner import get_runner
+
+
+cocotb_build_flags = [
+    "hdl_library",
+    "verilog_sources",
+    "vhdl_sources",
+    "includes",
+    "defines",
+    "parameters",
+    "build_args",
+    "hdl_toplevel",
+    "always",
+    "build_dir",
+    "verbose",
+]
+
+
+cocotb_test_flags = [
+    "test_module",
+    "hdl_toplevel",
+    "hdl_toplevel_library",
+    "hdl_toplevel_lang",
+    "gpi_interfaces",
+    "testcase",
+    "seed",
+    "test_args",
+    "plusargs",
+    "extra_env",
+    "waves",
+    "gui",
+    "parameters",
+    "build_dir",
+    "test_dir",
+    "results_xml",
+    "verbose",
+]
+
+
+def filter_args(kwargs, keys):
+    return {k: v for (k, v) in kwargs.items() if k in keys}
+
+
+def cocotb_argument_parser():
+    class ParseDict(argparse.Action):
+        def __call__(self, parser, namespace, values, option_string=None):
+            setattr(namespace, self.dest, dict())
+            for value in values:
+                key, value = value.split("=")
+                getattr(namespace, self.dest)[key] = value
+
+    parser = argparse.ArgumentParser(description="Runs the Cocotb framework from Bazel")
+
+    parser.add_argument("--sim", default="icarus", help="Dafault simulator")
+    parser.add_argument(
+        "--hdl_library", default="top", help="The library name to compile into"
+    )
+    parser.add_argument(
+        "--verilog_sources", nargs="*", default=[], help="Verilog source files to build"
+    )
+    parser.add_argument(
+        "--vhdl_sources", nargs="*", default=[], help="VHDL source files to build"
+    )
+    parser.add_argument(
+        "--includes", nargs="*", default=[], help="Verilog include directories"
+    )
+    parser.add_argument(
+        "--defines", nargs="*", default={}, action=ParseDict, help="Defines to set"
+    )
+    parser.add_argument(
+        "--parameters",
+        nargs="*",
+        default={},
+        action=ParseDict,
+        help="Verilog parameters or VHDL generics",
+    )
+    parser.add_argument(
+        "--build_args",
+        nargs="*",
+        default=[],
+        help="Extra build arguments for the simulator",
+    )
+    parser.add_argument(
+        "--hdl_toplevel", default=None, help="Name of the HDL toplevel module"
+    )
+    parser.add_argument(
+        "--always",
+        default=False,
+        action="store_true",
+        help="Name of the HDL toplevel module",
+    )
+    parser.add_argument(
+        "--build_dir", default="sim_build", help="Directory to run the build step in"
+    )
+    parser.add_argument(
+        "--verbose", default=False, action="store_true", help="Enable verbose messages"
+    )
+    parser.add_argument(
+        "--test_module",
+        nargs="*",
+        default=[],
+        help="Name(s) of the Python module(s) containing the tests to run",
+    )
+    parser.add_argument(
+        "--hdl_toplevel_library", help="The library name for HDL toplevel module"
+    )
+    parser.add_argument(
+        "--hdl_toplevel_lang", default=None, help="Language of the HDL toplevel module"
+    )
+    parser.add_argument(
+        "--gpi_interfaces",
+        default=None,
+        help="List of GPI interfaces to use, with the first one being the entry point",
+    )
+    parser.add_argument(
+        "--testcase", default=None, help="Name(s) of a specific testcase(s) to run"
+    )
+    parser.add_argument("--seed", default=None, help="A specific random seed to use")
+    parser.add_argument(
+        "--plusargs", default=[], help="'plusargs' to set for the simulator"
+    )
+    parser.add_argument(
+        "--extra_env",
+        nargs="*",
+        default={},
+        action=ParseDict,
+        help="Extra environment variables to set",
+    )
+    parser.add_argument(
+        "--waves", action="store_true", default=None, help="Record signal traces"
+    )
+    parser.add_argument(
+        "--gui", action="store_true", default=None, help="Record signal traces"
+    )
+    parser.add_argument(
+        "--test_dir", default=None, help="Directory to run the build step in"
+    )
+    parser.add_argument(
+        "--results_xml",
+        default="results.xml",
+        help="Name of xUnit XML file to store test results in",
+    )
+
+    return parser
+
+
+if __name__ == "__main__":
+    parser = cocotb_argument_parser()
+    args = parser.parse_args()
+
+    build_flags = filter_args(vars(args), cocotb_build_flags)
+    test_flags = filter_args(vars(args), cocotb_test_flags)
+
+    runner = get_runner(args.sim)
+
+    runner.build(**build_flags)
+    runner.test(**test_flags),

--- a/cocotb/tests/BUILD
+++ b/cocotb/tests/BUILD
@@ -1,0 +1,37 @@
+# Copyright 2023 Antmicro
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//cocotb:cocotb.bzl", "cocotb_test")
+load("//verilog:providers.bzl", "verilog_library")
+load("@rules_hdl_pip_deps//:requirements.bzl", "requirement")
+
+verilog_library(
+    name = "counter",
+    srcs = ["counter.v"],
+)
+
+cocotb_test(
+    name = "cocotb_counter",
+    defines = {"INIT_CNT": "100"},
+    hdl_toplevel = "counter",
+    hdl_toplevel_lang = "verilog",
+    parameters = {"COUNTER_WIDTH": "8"},
+    seed = "1234567890",
+    test_module = ["cocotb_counter.py"],
+    verilog_sources = [
+        ":counter",
+        "wavedump.v",
+    ],
+    deps = [requirement("cocotb")],
+)

--- a/cocotb/tests/cocotb_counter.py
+++ b/cocotb/tests/cocotb_counter.py
@@ -1,0 +1,33 @@
+# Copyright 2023 Antmicro
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import cocotb
+from cocotb.clock import Clock
+from cocotb.triggers import RisingEdge, ClockCycles
+
+
+@cocotb.test()
+async def counter_test(dut):
+    clock = Clock(dut.clk, 10, units="us")
+    cocotb.start_soon(clock.start())
+
+    dut.rst.setimmediatevalue(1)
+    await RisingEdge(dut.clk)
+    dut.rst.value = 0
+
+    reset_value = int(dut.cnt.value)
+
+    CYCLES_TO_WAIT = 10
+    await ClockCycles(dut.clk, CYCLES_TO_WAIT)
+    assert dut.cnt.value == reset_value + CYCLES_TO_WAIT - 1

--- a/cocotb/tests/counter.v
+++ b/cocotb/tests/counter.v
@@ -1,0 +1,40 @@
+// Copyright 2023 Antmicro
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+`timescale 1us/1us
+
+module counter #(
+    parameter COUNTER_WIDTH = 32
+) (
+    input wire clk,
+    input wire rst,
+    output reg[COUNTER_WIDTH-1:0] cnt
+);
+
+`ifndef INIT_CNT
+`define INIT_CNT 0
+`endif
+
+initial begin
+  cnt = `INIT_CNT;
+end
+
+always @(posedge clk) begin
+    if (rst)
+        cnt <= `INIT_CNT;
+    else
+        cnt <= cnt + 1;
+end
+
+endmodule

--- a/cocotb/tests/wavedump.v
+++ b/cocotb/tests/wavedump.v
@@ -1,0 +1,20 @@
+// Copyright 2023 Antmicro
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module wavedump();
+initial begin
+    $dumpfile("dump.vcd");
+    $dumpvars(0, counter);
+end
+endmodule

--- a/dependency_support/com_icarus_iverilog/iverilog.sh
+++ b/dependency_support/com_icarus_iverilog/iverilog.sh
@@ -18,7 +18,12 @@
 
 set -eu
 
-dir=$(dirname $(find . -name iverilog-bin | head -n 1))
+iverilog_path="$(find . -name iverilog-bin | head -n 1)"
+if [ "$iverilog_path" == "" ]; then
+  iverilog_path="$(command -v iverilog-bin)"
+fi
+
+dir=$(dirname "$iverilog_path")
 
 if [[ ! -d "$dir" ]]; then
   echo "Unable to find dependencies (looking under $dir)." 1>&2

--- a/dependency_support/com_icarus_iverilog/vvp.sh
+++ b/dependency_support/com_icarus_iverilog/vvp.sh
@@ -18,7 +18,12 @@
 
 set -eu
 
-dir=$(dirname $(find . -name vvp-bin | head -n 1))
+vvp_path="$(find . -name vvp-bin | head -n 1)"
+if [ "$vvp_path" == "" ]; then
+  vvp_path="$(command -v vvp-bin)"
+fi
+
+dir=$(dirname "$vvp_path")
 
 if [[ ! -d "$dir" ]]; then
   echo "Unable to find dependencies (looking under $dir)." 1>&2

--- a/dependency_support/pip_requirements.txt
+++ b/dependency_support/pip_requirements.txt
@@ -2,3 +2,4 @@ dataclasses-json==0.5.7
 jwt==1.3.1
 requests==2.28.2
 absl-py==1.4.0
+cocotb==1.8.0


### PR DESCRIPTION
This PR adds the `cocotb_test` rule which may be used to test hardware designs using Cocotb framework. The created rule uses a simple Python script that filters arguments and passes them to the Cocotb Runner. Most of the arguments of the `cocotb_test` rule are passed directly to the runner. Besides that, a simple test with a counter has been added to test the created rule.