### PR TITLE
Improve cocotb_test rule

### DIFF
--- a/cocotb/BUILD
+++ b/cocotb/BUILD
@@ -12,13 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_hdl_pip_deps//:requirements.bzl", "requirement")
-
 py_binary(
     name = "cocotb_wrapper",
     srcs = ["cocotb_wrapper.py"],
     python_version = "PY3",
     srcs_version = "PY3",
     visibility = ["//visibility:public"],
-    deps = [requirement("cocotb")],
+    deps = [],
 )

--- a/cocotb/cocotb.bzl
+++ b/cocotb/cocotb.bzl
@@ -32,7 +32,7 @@ def _dict_to_argstring(data, argname):
     return result
 
 def _files_to_argstring(data, argname):
-    return _list_to_argstring(data, argname, "path")
+    return _list_to_argstring(data, argname, "short_path")
 
 def _pymodules_to_argstring(data, argname):
     remove_py = lambda s: s.removesuffix(".py")

--- a/cocotb/cocotb.bzl
+++ b/cocotb/cocotb.bzl
@@ -88,6 +88,7 @@ def _cocotb_test_impl(ctx):
     parameters_args = _dict_to_argstring(ctx.attr.parameters, "parameters")
 
     verbose_args = " --verbose" if ctx.attr.verbose else ""
+    waves_args = " --waves" if ctx.attr.waves else ""
     seed_args = " --seed {}".format(ctx.attr.seed) if ctx.attr.seed != "" else ""
 
     test_module_args = _pymodules_to_argstring(ctx.files.test_module, "test_module")
@@ -117,6 +118,7 @@ def _cocotb_test_impl(ctx):
         defines_args +
         parameters_args +
         verbose_args +
+        waves_args +
         seed_args +
         test_module_args
     )

--- a/cocotb/cocotb.bzl
+++ b/cocotb/cocotb.bzl
@@ -61,7 +61,7 @@ def _collect_verilog_files(ctx):
     ]
     verilog_files = depset(
         [src for sub_tuple in verilog_srcs for src in sub_tuple] +
-        ctx.files.verilog_sources
+        ctx.files.verilog_sources,
     )
     return verilog_files.to_list()
 
@@ -100,7 +100,7 @@ def _cocotb_test_impl(ctx):
 
     command = (
         "PATH={}:$PATH ".format(path) +
-        "python {}".format(ctx.executable._cocotb_wrapper.short_path) +
+        "python {}".format(ctx.executable.cocotb_wrapper.short_path) +
         " --sim {}".format(ctx.attr.sim_name) +
         " --hdl_library {}".format(ctx.attr.hdl_library) +
         " --hdl_toplevel {}".format(ctx.attr.hdl_toplevel) +
@@ -128,12 +128,12 @@ def _cocotb_test_impl(ctx):
     transitive_files = depset(
         direct = [py_toolchain.interpreter],
         transitive = [dep[PyInfo].transitive_sources for dep in ctx.attr.deps] +
-                     [ctx.attr._cocotb_wrapper[PyInfo].transitive_sources] +
+                     [ctx.attr.cocotb_wrapper[PyInfo].transitive_sources] +
                      [py_toolchain.files],
     )
 
     runfiles = ctx.runfiles(
-        files = ctx.files._cocotb_wrapper +
+        files = ctx.files.cocotb_wrapper +
                 verilog_files +
                 vhdl_files +
                 ctx.files.test_module,
@@ -249,7 +249,7 @@ _cocotb_test_attrs = {
         doc = "The list of python libraries to be linked in to the simulation target",
         providers = [PyInfo],
     ),
-    "_cocotb_wrapper": attr.label(
+    "cocotb_wrapper": attr.label(
         cfg = "exec",
         executable = True,
         doc = "Cocotb wrapper script",

--- a/cocotb/cocotb_wrapper.py
+++ b/cocotb/cocotb_wrapper.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import argparse
-from cocotb.runner import get_runner
+from cocotb.runner import get_runner, check_results_file
 
 
 cocotb_build_flags = [
@@ -167,6 +167,6 @@ if __name__ == "__main__":
     test_flags = filter_args(vars(args), cocotb_test_flags)
 
     runner = get_runner(args.sim)
-
     runner.build(**build_flags)
-    runner.test(**test_flags),
+    results_xml = runner.test(**test_flags)
+    check_results_file(results_xml)


### PR DESCRIPTION
This PR adds the following improvements to the existing `cocotb_test` rule:

* uses `short_path` of files instead of `path` to correctly handle the generated files
* removes the `cocotb_wrapper.py` dependency on the `cocotb` to prevent circular imports and double dependencies when the rule is imported into other repositories. I encountered that problem when I tried to use the `cocotb_bus` library in [the PR to XLS repository](https://github.com/google/xls/pull/1057). The `cocotb_bus` library itself relies on `cocotb`, as a result, I obtained one copy of cocotb from the `bazel_hdl_rules` repo and the second from the `xls` repository.
* adds all Python packages and their dependencies to the `PYTHONPATH` to correctly handle imports from other libraries
* makes the `cocotb_wrapper` attribute public to allow for specifying different entry for other cocotb versions or different build setups
