### PR TITLE
Change rule attributes from private to allow user customization.

### DIFF
--- a/vivado/defs.bzl
+++ b/vivado/defs.bzl
@@ -230,7 +230,7 @@ vivado_create_project = rule(
             doc = "Jobs to pass to vivado which defines the amount of parallelism.",
             default = 4,
         ),
-        "_create_project_tcl_template": attr.label(
+        "create_project_tcl_template": attr.label(
             doc = "The create project tcl template",
             default = "@rules_hdl//vivado:create_project.tcl.template",
             allow_single_file = [".template"],
@@ -292,7 +292,7 @@ vivado_synthesize = rule(
             doc = "Jobs to pass to vivado which defines the amount of parallelism.",
             default = 4,
         ),
-        "_create_project_tcl_template": attr.label(
+        "create_project_tcl_template": attr.label(
             doc = "The create project tcl template",
             default = "@rules_hdl//vivado:create_project.tcl.template",
             allow_single_file = [".template"],
@@ -360,7 +360,7 @@ vivado_synthesis_optimize = rule(
             doc = "Threads to pass to vivado which defines the amount of parallelism.",
             default = 8,
         ),
-        "_synthesis_optimize_template": attr.label(
+        "synthesis_optimize_template": attr.label(
             doc = "The synthesis optimzation tcl template",
             default = "@rules_hdl//vivado:synth_optimize.tcl.template",
             allow_single_file = [".template"],
@@ -426,7 +426,7 @@ vivado_placement = rule(
             doc = "Threads to pass to vivado which defines the amount of parallelism.",
             default = 8,
         ),
-        "_placement_template": attr.label(
+        "placement_template": attr.label(
             doc = "The placement tcl template",
             default = "@rules_hdl//vivado:placement.tcl.template",
             allow_single_file = [".template"],
@@ -492,7 +492,7 @@ vivado_place_optimize = rule(
             doc = "Threads to pass to vivado which defines the amount of parallelism.",
             default = 8,
         ),
-        "_place_optimize_template": attr.label(
+        "place_optimize_template": attr.label(
             doc = "The placement tcl template",
             default = "@rules_hdl//vivado:place_optimize.tcl.template",
             allow_single_file = [".template"],
@@ -574,7 +574,7 @@ vivado_routing = rule(
             doc = "Threads to pass to vivado which defines the amount of parallelism.",
             default = 8,
         ),
-        "_route_template": attr.label(
+        "route_template": attr.label(
             doc = "The placement tcl template",
             default = "@rules_hdl//vivado:route.tcl.template",
             allow_single_file = [".template"],
@@ -627,7 +627,7 @@ vivado_write_bitstream = rule(
             doc = "Threads to pass to vivado which defines the amount of parallelism.",
             default = 8,
         ),
-        "_write_bitstream_template": attr.label(
+        "write_bitstream_template": attr.label(
             doc = "The write bitstream tcl template",
             default = "@rules_hdl//vivado:write_bitstream.tcl.template",
             allow_single_file = [".template"],
@@ -781,7 +781,7 @@ xsim_test = rule(
             mandatory = True,
             allow_single_file = [".sh"],
         ),
-        "_xsim_test_template": attr.label(
+        "xsim_test_template": attr.label(
             doc = "The tcl template to run on vivado.",
             default = "@rules_hdl//vivado:xsim_test.tcl.template",
             allow_single_file = [".template"],
@@ -922,12 +922,12 @@ vivado_create_ip = rule(
             mandatory = True,
             allow_single_file = [".sh"],
         ),
-        "_create_ip_block_template": attr.label(
+        "create_ip_block_template": attr.label(
             doc = "The create project tcl template",
             default = "@rules_hdl//vivado:create_ip_block.tcl.template",
             allow_single_file = [".template"],
         ),
-        "_keyfile": attr.label(
+        "keyfile": attr.label(
             doc = "The keyfile to use when optionally encrypting",
             default = "@rules_hdl//vivado:xilinx_keyfile.txt",
             allow_single_file = [".txt"],


### PR DESCRIPTION
Change a number of the attributes in vivado rules to allow user modification. While the defaults should remain, there are some use cases where modifying these would be desired.