### PR TITLE
Enable designs targeting ASAP7 

### DIFF
--- a/dependency_support/org_theopenroadproject_asap7/bundled.BUILD.bazel
+++ b/dependency_support/org_theopenroadproject_asap7/bundled.BUILD.bazel
@@ -19,14 +19,14 @@ load("@rules_hdl//dependency_support/org_theopenroadproject_asap7:asap7.bzl", "a
 
 asap7_cell_library(
     name = "asap7_rvt_1x",
-    srcs = glob(["asap7sc7p5t_27/LIB/CCS/*.lib.gz"]),
-    cell_lef = "asap7sc7p5t_27/LEF/scaled/asap7sc7p5t_27_R_4x_201211.lef",
+    srcs = glob(["asap7sc7p5t_28/LIB/CCS/*.lib.gz"]),
+    cell_lef = "asap7sc7p5t_28/LEF/asap7sc7p5t_28_R_1x_220121a.lef",
     cell_type = "RVT",
-    platform_gds = "asap7sc7p5t_27/GDS/asap7sc7p5t_27_R_201211.gds",
+    platform_gds = "asap7sc7p5t_28/GDS/asap7sc7p5t_28_R_220121a.gds",
     default_corner_delay_model = "ccs",
     default_corner_swing = "SS",
     openroad_configuration = ":open_road_asap7_1x",
-    tech_lef = "asap7sc7p5t_27/techlef_misc/asap7_tech_4x_201209.lef",
+    tech_lef = "asap7sc7p5t_28/techlef_misc/asap7_tech_1x_201209.lef",
     visibility = [
         "//visibility:public",
     ]
@@ -65,7 +65,7 @@ open_road_pdk_configuration(
     pin_vertical_metal_layer = "M5",
     rc_script_configuration = "@rules_hdl//dependency_support/org_theopenroadproject_asap7:rc_script.tcl",
     tap_cell = "TAPCELL_ASAP7_75t_R",
-    tapcell_distance = 25 * 4,  # We are using the by 4 variants of these cells.
+    tapcell_distance = 25,
     tie_high_port = "TIEHIx1_ASAP7_75t_R/H",
     tie_low_port = "TIELOx1_ASAP7_75t_R/L",
     tie_separation = 0,

--- a/dependency_support/org_theopenroadproject_asap7/bundled.BUILD.bazel
+++ b/dependency_support/org_theopenroadproject_asap7/bundled.BUILD.bazel
@@ -47,6 +47,11 @@ open_road_pdk_configuration(
     endcap_cell = "TAPCELL_ASAP7_75t_R",
     fill_cells = [
         "FILLERxp5_ASAP7_75t_R",
+        "DECAPx1_ASAP7_75t_R",
+        "DECAPx2_ASAP7_75t_R",
+        "DECAPx4_ASAP7_75t_R",
+        "DECAPx6_ASAP7_75t_R",
+        "DECAPx10_ASAP7_75t_R",
     ],
     global_placement_cell_pad = 2,
     global_routing_clock_layers = "M2-M7",

--- a/dependency_support/org_theopenroadproject_asap7/org_theopenroadproject_asap7.bzl
+++ b/dependency_support/org_theopenroadproject_asap7/org_theopenroadproject_asap7.bzl
@@ -22,9 +22,9 @@ def org_theopenroadproject_asap7():
         http_archive,
         name = "org_theopenroadproject_asap7",
         urls = [
-            "https://github.com/The-OpenROAD-Project/asap7/archive/157c92cfd2567a98c5f794fb10c2dd0713516374.tar.gz",
+            "https://github.com/The-OpenROAD-Project/asap7/archive/cd13de4e603913291ec6b8401ab63ec481178a5a.tar.gz",
         ],
-        strip_prefix = "asap7-157c92cfd2567a98c5f794fb10c2dd0713516374",
-        sha256 = "bfa76681ee0f1b109cb73415728cf3d7508ce0be88ac491962e8a0016033a683",
+        strip_prefix = "asap7-cd13de4e603913291ec6b8401ab63ec481178a5a",
+        sha256 = "1820b732362852ec9658695c7509dd81eda571bb6b64def48ff92e2fab78fbe8",
         build_file = Label("@rules_hdl//dependency_support/org_theopenroadproject_asap7:bundled.BUILD.bazel"),
     )

--- a/dependency_support/org_theopenroadproject_asap7/pdn_config.pdn
+++ b/dependency_support/org_theopenroadproject_asap7/pdn_config.pdn
@@ -28,15 +28,11 @@ set_voltage_domain -name {CORE} -power {VDD} -ground {VSS}
 ####################################
 # standard cell grid
 ####################################
-# ASAP7 in its default configuration is multipled by 
-# 4x looking to fix this upstream.
-set multipler 4.0
-
 define_pdn_grid -name {top} -voltage_domains {CORE}
-add_pdn_stripe -grid {top} -layer {M1} -width {0.072} -pitch {2.16} -offset {0} -followpins
-add_pdn_stripe -grid {top} -layer {M2} -width {0.072} -pitch {2.16} -offset {0} -followpins
-add_pdn_stripe -grid {top} -layer {M5} -width {0.48} -spacing {0.288} -pitch {47.52} -offset {1.188}
-add_pdn_stripe -grid {top} -layer {M6} -width {1.1520} -spacing {0.384} -pitch {48} -offset {2.556}
+add_pdn_stripe -grid {top} -layer {M1} -width {0.018} -pitch {0.54} -offset {0} -followpins
+add_pdn_stripe -grid {top} -layer {M2} -width {0.018} -pitch {0.54} -offset {0} -followpins
+add_pdn_stripe -grid {top} -layer {M5} -width {0.12} -spacing {0.072} -pitch {11.88} -offset {0.300}
+add_pdn_stripe -grid {top} -layer {M6} -width {0.288} -spacing {0.096} -pitch {12} -offset {0.513}
 add_pdn_connect -grid {top} -layers {M1 M2}
 add_pdn_connect -grid {top} -layers {M2 M5}
 add_pdn_connect -grid {top} -layers {M5 M6}

--- a/dependency_support/org_theopenroadproject_asap7/rc_script.tcl
+++ b/dependency_support/org_theopenroadproject_asap7/rc_script.tcl
@@ -12,24 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set_layer_rc -layer M1 -capacitance 6.33956E-02 -resistance 1.3889e-01
-set_layer_rc -layer M2 -capacitance 8.02750E-02 -resistance 2.4222e-02
-set_layer_rc -layer M3 -capacitance 1.23273E-01 -resistance 2.4222e-02
-set_layer_rc -layer M4 -capacitance 1.29902E-01 -resistance 1.6778e-02
-set_layer_rc -layer M5 -capacitance 1.19552E-01 -resistance 1.4677e-02
-set_layer_rc -layer M6 -capacitance 1.23114E-01 -resistance 1.0371e-02
-set_layer_rc -layer M7 -capacitance 1.05408E-01 -resistance 9.6720e-03
+# Liberty units are fF,kOhm
+set_layer_rc -layer M1 -capacitance 1.1368e-01 -resistance 1.3889e-01
+set_layer_rc -layer M2 -capacitance 1.3426e-01 -resistance 2.4222e-02
+set_layer_rc -layer M3 -capacitance 1.2918e-01 -resistance 2.4222e-02
+set_layer_rc -layer M4 -capacitance 1.1396e-01 -resistance 1.6778e-02
+set_layer_rc -layer M5 -capacitance 1.3323e-01 -resistance 1.4677e-02
+set_layer_rc -layer M6 -capacitance 1.1575e-01 -resistance 1.0371e-02
+set_layer_rc -layer M7 -capacitance 1.3293e-01 -resistance 9.6720e-03
 set_layer_rc -layer M8 -capacitance 1.1822e-01 -resistance 7.4310e-03
 set_layer_rc -layer M9 -capacitance 1.3497e-01 -resistance 6.8740e-03
 
-set_layer_rc -via V1 -resistance 1.00E-02
-set_layer_rc -via V2 -resistance 1.00E-02
-set_layer_rc -via V3 -resistance 1.00E-02
-set_layer_rc -via V4 -resistance 1.00E-02
-set_layer_rc -via V5 -resistance 1.00E-02
-set_layer_rc -via V6 -resistance 1.00E-02
-set_layer_rc -via V7 -resistance 1.00E-02
-set_layer_rc -via V8 -resistance 1.00E-02
-set_layer_rc -via V9 -resistance 1.00E-02
+set_layer_rc -via V1 -resistance 1.72E-02
+set_layer_rc -via V2 -resistance 1.72E-02
+set_layer_rc -via V3 -resistance 1.72E-02
+set_layer_rc -via V4 -resistance 1.18E-02
+set_layer_rc -via V5 -resistance 1.18E-02
+set_layer_rc -via V6 -resistance 8.20E-03
+set_layer_rc -via V7 -resistance 8.20E-03
+set_layer_rc -via V8 -resistance 6.30E-03
 
 set_wire_rc -layer M3

--- a/dependency_support/org_theopenroadproject_asap7/tracks.tcl
+++ b/dependency_support/org_theopenroadproject_asap7/tracks.tcl
@@ -12,24 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set multiplier 4
+make_tracks Pad -x_offset 0.116 -x_pitch 0.080 -y_offset 0.116 -y_pitch 0.080
+make_tracks M9  -x_offset 0.116 -x_pitch 0.080 -y_offset 0.116 -y_pitch 0.080
+make_tracks M8  -x_offset 0.116 -x_pitch 0.080 -y_offset 0.116 -y_pitch 0.080
+make_tracks M7  -x_offset 0.016 -x_pitch 0.064 -y_offset 0.016 -y_pitch 0.064
+make_tracks M6  -x_offset 0.012 -x_pitch 0.048 -y_offset 0.016 -y_pitch 0.064
+make_tracks M5  -x_offset 0.012 -x_pitch 0.048 -y_offset 0.012 -y_pitch 0.048
+make_tracks M4  -x_offset 0.009 -x_pitch 0.036 -y_offset 0.012 -y_pitch 0.048
+make_tracks M3  -x_offset 0.009 -x_pitch 0.036 -y_offset 0.009 -y_pitch 0.036
 
-make_tracks Pad -x_offset [expr 0.116 * $multiplier] -x_pitch [expr 0.08  * $multiplier] -y_offset [expr 0.116 * $multiplier] -y_pitch [expr 0.08 * $multiplier]
-make_tracks M9  -x_offset [expr 0.116 * $multiplier] -x_pitch [expr 0.08  * $multiplier] -y_offset [expr 0.116 * $multiplier] -y_pitch [expr 0.08 * $multiplier]
-make_tracks M8  -x_offset [expr 0.116 * $multiplier] -x_pitch [expr 0.08  * $multiplier] -y_offset [expr 0.116 * $multiplier] -y_pitch [expr 0.08 * $multiplier]
-make_tracks M7  -x_offset [expr 0.016 * $multiplier] -x_pitch [expr 0.064 * $multiplier] -y_offset [expr 0.016 * $multiplier] -y_pitch [expr 0.064 * $multiplier]
-make_tracks M6  -x_offset [expr 0.012 * $multiplier] -x_pitch [expr 0.048 * $multiplier] -y_offset [expr 0.016 * $multiplier] -y_pitch [expr 0.064 * $multiplier]
-make_tracks M5  -x_offset [expr 0.012 * $multiplier] -x_pitch [expr 0.048 * $multiplier] -y_offset [expr 0.012 * $multiplier] -y_pitch [expr 0.048 * $multiplier]
-make_tracks M4  -x_offset [expr 0.009 * $multiplier] -x_pitch [expr 0.036 * $multiplier] -y_offset [expr 0.012 * $multiplier] -y_pitch [expr 0.048 * $multiplier]
-make_tracks M3  -x_offset [expr 0.009 * $multiplier] -x_pitch [expr 0.036 * $multiplier] -y_offset [expr 0.009 * $multiplier] -y_pitch [expr 0.036 * $multiplier]
+make_tracks M2  -x_offset 0.009 -x_pitch 0.036 -y_offset 0.045 -y_pitch 0.270
+make_tracks M2  -x_offset 0.009 -x_pitch 0.036 -y_offset 0.081 -y_pitch 0.270
+make_tracks M2  -x_offset 0.009 -x_pitch 0.036 -y_offset 0.117 -y_pitch 0.270
+make_tracks M2  -x_offset 0.009 -x_pitch 0.036 -y_offset 0.153 -y_pitch 0.270
+make_tracks M2  -x_offset 0.009 -x_pitch 0.036 -y_offset 0.189 -y_pitch 0.270
+make_tracks M2  -x_offset 0.009 -x_pitch 0.036 -y_offset 0.225 -y_pitch 0.270
+make_tracks M2  -x_offset 0.009 -x_pitch 0.036 -y_offset 0.270 -y_pitch 0.270
 
-# Creating multiple sub tracks for metal M2 for off grid routing purposes.
-make_tracks M2  -x_offset [expr 0.009 * $multiplier] -x_pitch [expr 0.036 * $multiplier] -y_offset [expr (0.045 - 0.000) * $multiplier] -y_pitch [expr 0.270 * $multiplier]
-make_tracks M2  -x_offset [expr 0.009 * $multiplier] -x_pitch [expr 0.036 * $multiplier] -y_offset [expr (0.081 - 0.000) * $multiplier] -y_pitch [expr 0.270 * $multiplier]
-make_tracks M2  -x_offset [expr 0.009 * $multiplier] -x_pitch [expr 0.036 * $multiplier] -y_offset [expr (0.117 - 0.000) * $multiplier] -y_pitch [expr 0.270 * $multiplier]
-make_tracks M2  -x_offset [expr 0.009 * $multiplier] -x_pitch [expr 0.036 * $multiplier] -y_offset [expr (0.153 - 0.000) * $multiplier] -y_pitch [expr 0.270 * $multiplier]
-make_tracks M2  -x_offset [expr 0.009 * $multiplier] -x_pitch [expr 0.036 * $multiplier] -y_offset [expr (0.189 - 0.000) * $multiplier] -y_pitch [expr 0.270 * $multiplier]
-make_tracks M2  -x_offset [expr 0.009 * $multiplier] -x_pitch [expr 0.036 * $multiplier] -y_offset [expr (0.225 - 0.000) * $multiplier] -y_pitch [expr 0.270 * $multiplier]
-make_tracks M2  -x_offset [expr 0.009 * $multiplier] -x_pitch [expr 0.036 * $multiplier] -y_offset [expr (0.270 - 0.000) * $multiplier] -y_pitch [expr 0.270 * $multiplier]
-
-make_tracks M1  -x_offset [expr 0.009 * $multiplier] -x_pitch [expr 0.036 * $multiplier] -y_offset [expr 0.009 * $multiplier] -y_pitch [expr 0.036 * $multiplier]
+make_tracks M1  -x_offset 0.009 -x_pitch 0.036 -y_offset 0.009 -y_pitch 0.036

--- a/synthesis/tests/BUILD
+++ b/synthesis/tests/BUILD
@@ -66,9 +66,25 @@ run_opensta(
     synth_target = ":verilog_counter_asap7_synth",
 )
 
+gds_write(
+    name = "counter_asap7_asic",
+    implemented_rtl = ":counter_asap7_place_and_route",
+)
+
+place_and_route(
+    name = "counter_asap7_place_and_route",
+    core_padding_microns = 1,
+    die_height_microns = 20,
+    die_width_microns = 20,
+    placement_density = "0.65",
+    sdc = "constraint.sdc",
+    synthesized_rtl = ":verilog_counter_asap7_synth",
+)
+
 synthesize_rtl(
     name = "verilog_counter_asap7_synth",
     standard_cells = "@org_theopenroadproject_asap7//:asap7_rvt_1x",
+    target_clock_period_pico_seconds = 10000,
     top_module = "counter",
     deps = [
         ":verilog_counter",

--- a/synthesis/tests/constraint.sdc
+++ b/synthesis/tests/constraint.sdc
@@ -1,0 +1,16 @@
+current_design counter
+
+set clk_name  core_clock
+set clk_port_name clk
+set clk_period 10000
+set clk_io_pct 0.2
+
+set clk_port [get_ports $clk_port_name]
+
+create_clock -name $clk_name -period $clk_period  $clk_port
+
+set non_clock_inputs [lsearch -inline -all -not -exact [all_inputs] $clk_port]
+
+set_input_delay  [expr $clk_period * $clk_io_pct] -clock $clk_name $non_clock_inputs
+set_output_delay [expr $clk_period * $clk_io_pct] -clock $clk_name [all_outputs]
+


### PR DESCRIPTION
Fixes https://github.com/hdl/bazel_rules_hdl/issues/172

Requires merging https://github.com/hdl/bazel_rules_hdl/pull/178 in order to fix errors from `buildifier`.

This PR:
* bumps ASAP7 dependency,
* changes the default settings of the PDK dependency to use non-scaled variant,
* updates ASAP7 config files (`pdn_config.pdn`, `rc_script.tcl`, `tracks.tcl`) to match non-scaled variant of the PDK,
* adds test which implements physical layout of counter example targeting ASAP7 technology.

@QuantamHD , @proppy please take a look at this