### PR TITLE
Upgrade googletest to `v1.14.0` release.

### DIFF
--- a/dependency_support/com_google_googletest/com_google_googletest.bzl
+++ b/dependency_support/com_google_googletest/com_google_googletest.bzl
@@ -21,7 +21,7 @@ def com_google_googletest():
     maybe(
         http_archive,
         name = "com_google_googletest",
-        urls = ["https://github.com/google/googletest/archive/0eea2e9fc63461761dea5f2f517bd6af2ca024fa.zip"],  # 2020-04-30
-        strip_prefix = "googletest-0eea2e9fc63461761dea5f2f517bd6af2ca024fa",
-        sha256 = "9463ff914d7c3db02de6bd40a3c412a74e979e3c76eaa89920a49ff8488d6d69",
+	urls = ["https://github.com/google/googletest/archive/refs/tags/v1.14.0.zip"],  # Release 2nd Aug 2023
+        strip_prefix = "googletest-1.14.0",
+        sha256 = "1f357c27ca988c3f7c6b4bf68a9395005ac6761f034046e9dde0896e3aba00e4",
     )


### PR DESCRIPTION
Fixes #193.