### PR TITLE
Export pdk/build_defs.bzl so that StandardCellInfo can be used (and tested) by XLS

### DIFF
--- a/pdk/BUILD
+++ b/pdk/BUILD
@@ -11,3 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+exports_files(["build_defs.bzl"])


### PR DESCRIPTION
Not sure if I need to export `open_road_configuration` as well, or just the entry point?   The goal is to access  `do_not_use_cell_list`.   This is the only export I need internally.

