### PR TITLE
Add a line to synth.tcl to remove Yosys $print cells.

### DIFF
--- a/synthesis/synth.tcl
+++ b/synthesis/synth.tcl
@@ -52,6 +52,9 @@ yosys proc -nomux
 yosys proc_mux
 yosys flatten
 
+# Remove $print cells.
+yosys delete {*/t:$print}
+
 # Remove internal only aliases for public nets and then give created instances
 # useful names. At this stage it is mainly flipflops created by the `proc`
 # pass.

--- a/synthesis/synth.tcl
+++ b/synthesis/synth.tcl
@@ -52,7 +52,9 @@ yosys proc -nomux
 yosys proc_mux
 yosys flatten
 
-# Remove $print cells.
+# Remove $print cells.  These cells represent Verilog $display() tasks.
+# Some place and route tools cannot handle these in the output Verilog,
+# so remove them here.
 yosys delete {*/t:$print}
 
 # Remove internal only aliases for public nets and then give created instances


### PR DESCRIPTION
Add a command to Yosys synthesis scripts to delete $print cells.
These cells would result in `always` blocks and $display tasks in the synthesized netlist;
some backend tools can't handle these.