### PR TITLE
pdk/proto/extract_lef_and_liberty: fix duplicate fields

### DIFF
--- a/pdk/proto/build_defs.bzl
+++ b/pdk/proto/build_defs.bzl
@@ -28,12 +28,6 @@ def _extract_lef_and_liberty_impl(ctx):
         content.append("tech_lef_path: \"{}\"".format(ctx.attr.tech_lef_path))
         content.append("liberty_path: \"{}\"".format(ctx.attr.liberty_path))
 
-    content.append("tech_lef_path: \"{}\"".format(standard_cell.tech_lef.short_path))
-    out_files.append(standard_cell.tech_lef)
-
-    content.append("liberty_path: \"{}\"".format(standard_cell.default_corner.liberty.short_path))
-    out_files.append(standard_cell.default_corner.liberty)
-
     content.append("tracks_file_path: \"{}\"".format(
         open_road_configuration.tracks_file.short_path,
     ))


### PR DESCRIPTION
This is due to https://github.com/hdl/bazel_rules_hdl/pull/189, it correctly handled `cell_lef_paths` but forgot to remove `tech_lef_path` and `liberty_path` that are already handled by the if/else block.
