### PR TITLE
Adding `toolchain=None` to `ctx.actions.run` targets.

### DIFF
--- a/place_and_route/open_road.bzl
+++ b/place_and_route/open_road.bzl
@@ -259,6 +259,7 @@ def openroad_command(ctx, commands, input_db = None, step_name = None, inputs = 
         },
         execution_requirements = execution_requirements,
         mnemonic = "OpenROAD",
+	toolchain = None,
     )
 
     return struct(db = output_db, log_file = log_file)

--- a/static_timing/build_defs.bzl
+++ b/static_timing/build_defs.bzl
@@ -54,6 +54,7 @@ def _run_opensta_impl(ctx):
         input_manifests = input_manifests,
         env = env,
         mnemonic = "RunningSTA",
+	toolchain = None,
     )
 
     return [

--- a/synthesis/build_defs.bzl
+++ b/synthesis/build_defs.bzl
@@ -150,6 +150,7 @@ def _synthesize_design_impl(ctx):
         input_manifests = input_manifests,
         env = env,
         mnemonic = "SynthesizingRTL",
+	toolchain = None,
     )
 
     return [


### PR DESCRIPTION
Fixes the following issue (and similar in `bazel_rules_hdl/place_and_route/open_road.bzl`)
```
tansell@tansell-top:/XXX/google3$ blaze build //third_party/bazel_rules_hdl/synthesis/tests:verilog_counter-asap7-sc7p5t_rev28_lvt-place_and_route
ERROR: /XXX/google3/third_party/bazel_rules_hdl/synthesis/tests/BUILD:98:14: in synthesize_rtl rule //third_party/bazel_rules_hdl/synthesis/tests:verilog_counter-asap7-sc7p5t_rev28_lvt-synth:
Traceback (most recent call last):
        File "/XXX/google3/third_party/bazel_rules_hdl/synthesis/build_defs.bzl", line 144, column 20, in _synthesize_design_impl
                ctx.actions.run(
Error in run: Couldn't identify if tools are from implicit dependencies or a toolchain. Please set the toolchain parameter. If you're not using a toolchain, set it to 'None'.
ERROR: /XXX/google3/third_party/bazel_rules_hdl/synthesis/tests/BUILD:98:14: Analysis of target '//third_party/bazel_rules_hdl/synthesis/tests:verilog_counter-asap7-sc7p5t_rev28_lvt-synth' failed
ERROR: Analysis of target '//third_party/bazel_rules_hdl/synthesis/tests:verilog_counter-asap7-sc7p5t_rev28_lvt-place_and_route' failed; build aborted: Analysis failed
INFO: Elapsed time: 0.198s, Critical Path: 0.01s, Remote (0.00% of the time): [queue: 0.00%, setup: 0.00%, process: 0.00%]
ERROR: Build did NOT complete successfully
```