### PR TITLE
Add `mmap.mmap` as argument type.

### DIFF
--- a/pdk/liberty/liberty_utility.py
+++ b/pdk/liberty/liberty_utility.py
@@ -15,13 +15,14 @@
 """Utility functions to prepare the comibined liberty file."""
 
 import itertools
-from typing import List
+import mmap
+from typing import List, Union
 
 from pdk.liberty import cell_parser
 
 
 def generate_merged_liberty_io_vector(
-    liberty_files: List[bytes]) -> List[bytes]:
+    liberty_files: List[Union[bytes, mmap.mmap]]) -> List[bytes]:
   """Generates a merged io vector representing a combined liberty file.
 
   Args:


### PR DESCRIPTION
Fixes;
```
ERROR: /XXXX/pdk/liberty/BUILD:19:21: Checking Python types for pdk/liberty/combine_liberty.py failed: (Exit 1)
pytype.par failed: error executing PytypeCheck command (from target pdk/liberty:combine_liberty@pytype@check) tools/python/pytype/pytype.par --strict-none-binding --use-enum-overlay --check --touch ... (remaining 13 arguments skipped).  [forge_remote_host=jabdj1]
File "pdk/liberty/combine_liberty.py", line 61, in main: Function pdk.liberty.liberty_utility.generate_merged_liberty_io_vector was called with the wrong arguments [wrong-arg-types]
         Expected: (liberty_files: List[bytes])
  Actually passed: (liberty_files: List[mmap.mmap])
```