### PR TITLE
Load the `py_XXX` targets.

### DIFF
--- a/cocotb/BUILD
+++ b/cocotb/BUILD
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_python//python:defs.bzl", "py_binary")
+
 py_binary(
     name = "cocotb_wrapper",
     srcs = ["cocotb_wrapper.py"],

--- a/pdk/liberty/BUILD
+++ b/pdk/liberty/BUILD
@@ -15,6 +15,7 @@
 """ASAP7 PDK Package"""
 
 load("@rules_hdl_pip_deps//:requirements.bzl", "requirement")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 
 py_binary(
     name = "combine_liberty",

--- a/vivado/tests/BUILD
+++ b/vivado/tests/BUILD
@@ -1,3 +1,4 @@
+load("@rules_python//python:defs.bzl", "py_binary")
 load("//verilator:defs.bzl", "verilator_cc_library")
 load("//verilog:providers.bzl", "verilog_library")
 load(


### PR DESCRIPTION
Use the targets from `@rules_python//python:defs.bzl` rather than the native targets (which are being deprecated).