### PR TITLE
Synthesis and P&R: Move closer to OpenROAD-flow-scripts

### DIFF
--- a/place_and_route/build_defs.bzl
+++ b/place_and_route/build_defs.bzl
@@ -105,5 +105,6 @@ place_and_route = rule(
         "sink_clustering_size": attr.int(doc = "Clock tree synthesis sink group size"),
         "sink_clustering_max_diameter": attr.int(doc = "Clock tree synthesis sink group desired diamater in microns"),
         "min_pin_distance": attr.string(doc = "The minimum distance in microns between pins around the outside of the block."),
+        "enable_improve_placement": attr.bool(default=True, doc = "Enable/Disable improve_placement pass.")
     },
 )

--- a/place_and_route/open_road.bzl
+++ b/place_and_route/open_road.bzl
@@ -210,9 +210,9 @@ def openroad_command(ctx, commands, input_db = None, step_name = None, inputs = 
 
     output_db = None
     if step_name:
-        output_db = ctx.actions.declare_file("{}__{}.db".format(ctx.attr.name, step_name))
+        output_db = ctx.actions.declare_file("{}__{}.odb".format(ctx.attr.name, step_name))
     else:
-        output_db = ctx.actions.declare_file("{}{}.db".format(input_hash, command_hash))
+        output_db = ctx.actions.declare_file("{}{}.odb".format(input_hash, command_hash))
 
     real_commands = []
     if input_db:

--- a/place_and_route/private/clock_tree_synthesis.bzl
+++ b/place_and_route/private/clock_tree_synthesis.bzl
@@ -47,6 +47,7 @@ def clock_tree_synthesis(ctx, open_road_info):
             sink_clustering_max_diameter = "-sink_clustering_max_diameter {}".format(ctx.attr.sink_clustering_max_diameter) if ctx.attr.sink_clustering_max_diameter else "",
         ),
         "set_propagated_clock [all_clocks]",
+        "estimate_parasitics -placement",
         "repair_clock_nets",
         "estimate_parasitics -placement",
     ] + placement_padding_struct.commands + [

--- a/place_and_route/private/detailed_routing.bzl
+++ b/place_and_route/private/detailed_routing.bzl
@@ -76,6 +76,24 @@ def detailed_routing(ctx, open_road_info):
                                   "\n}")
         open_road_commands.append("density_fill -rules {}".format(density_fill_config.path))
         inputs.append(density_fill_config)
+
+    open_road_commands.append("puts \"report_checks -path_delay min_max -format full_clock_expanded -fields {input_pin slew capacitance} -digits 3\"")
+    open_road_commands.append("report_checks -path_delay min_max -format full_clock_expanded -fields {input_pin slew capacitance} -digits 3")
+
+    open_road_commands.append("puts \"report_wns\"")
+    open_road_commands.append("report_wns")
+
+    open_road_commands.append("puts \"report_tns\"")
+    open_road_commands.append("report_tns")
+
+    open_road_commands.append("puts \"report_check_types -max_slew -max_capacitance -max_fanout -violators\"")
+    open_road_commands.append("report_check_types -max_slew -max_capacitance -max_fanout -violators")
+
+    open_road_commands.append("puts \"report_floating_nets -verbose\"")
+    open_road_commands.append("report_floating_nets -verbose")
+
+    open_road_commands.append("puts \"report_units\"")
+    open_road_commands.append("report_units")
     open_road_commands.append("write_def {}".format(routed_def.path))
 
     execution_requirements = {}

--- a/place_and_route/private/detailed_routing.bzl
+++ b/place_and_route/private/detailed_routing.bzl
@@ -55,8 +55,10 @@ def detailed_routing(ctx, open_road_info):
         if detailed_routing_configs.enable_via_gen:
             detailed_routing_args += " -disable_via_gen "
 
-    open_road_commands = timing_setup_command_struct.commands
-    open_road_commands.append("detailed_route -output_drc {} {}".format(output_drc.path, detailed_routing_args))
+    open_road_commands = timing_setup_command_struct.commands + [
+        "set_propagated_clock [all_clocks]",
+        "detailed_route -output_drc {} {}".format(output_drc.path, detailed_routing_args)
+    ]
     density_fill_config = None
     if open_road_configuration.density_fill_config:
         density_fill_config = open_road_configuration.density_fill_config.files.to_list()[0]

--- a/place_and_route/private/global_placement.bzl
+++ b/place_and_route/private/global_placement.bzl
@@ -40,7 +40,7 @@ def global_placement(ctx, open_road_info):
             pad_left = open_road_configuration.global_placement_cell_pad,
             pad_right = open_road_configuration.global_placement_cell_pad,
         ),
-        "remove_buffers",
+        "estimate_parasitics -placement",
     ]
 
     command_output = openroad_command(

--- a/place_and_route/private/resize.bzl
+++ b/place_and_route/private/resize.bzl
@@ -51,7 +51,7 @@ def resize(ctx, open_road_info):
         ),
     ] + placement_padding_struct.commands + [
         "detailed_placement",
-        "improve_placement",
+        "improve_placement" if ctx.attr.enable_improve_placement else "",
         "optimize_mirroring",
         "check_placement -verbose",
         "report_checks -path_delay min_max -format full_clock_expanded -fields {input_pin slew capacitance} -digits 3",

--- a/synthesis/BUILD
+++ b/synthesis/BUILD
@@ -22,6 +22,7 @@ package(
 )
 
 exports_files(["synth.tcl"])
+exports_files(["abc.script"])
 
 pkg_tar(
     name = "yosys",

--- a/synthesis/abc.script
+++ b/synthesis/abc.script
@@ -1,0 +1,45 @@
+&get -n
+&st
+&dch
+&nf
+&put
+&get -n
+&st
+&syn2
+&if -g -K 6
+&synch2
+&nf
+&put
+&get -n
+&st
+&syn2
+&if -g -K 6
+&synch2
+&nf
+&put
+&get -n
+&st
+&syn2
+&if -g -K 6
+&synch2
+&nf
+&put
+&get -n
+&st
+&syn2
+&if -g -K 6
+&synch2
+&nf
+&put
+&get -n
+&st
+&syn2
+&if -g -K 6
+&synch2
+&nf
+&put
+buffer -c
+topo
+stime -c
+upsize -c
+dnsize -c


### PR DESCRIPTION
Synthesis:
This commit adds a custom abc.script from OpenROAD-flow-scripts. This commit also modifies the synthesis script. It adds 2 new steps: extract adders - it tries to map addition chains to PDK specific full adder and half adder improving overall performance. Runs only when `adder_mapping` attr is provided.
tie logic cells - it runs `hilomap` pass.

P&R:
This commit changes output_db file extention to .odb. OpenROAD file explorer only allows for .odb to be opened from GUI.

Allow user to disable `improve_placement` pass during resize step. It can cause cell overlapping both by not maintaining sufficient cell to cell spacing as well as true cell overlapping.
Some other minor changes to the P&R scripts.

Edit:
Related to #239 