### PR TITLE
Add option to enable/disable `improve_placement` for P&R targets

### DIFF
--- a/place_and_route/build_defs.bzl
+++ b/place_and_route/build_defs.bzl
@@ -105,5 +105,6 @@ place_and_route = rule(
         "sink_clustering_size": attr.int(doc = "Clock tree synthesis sink group size"),
         "sink_clustering_max_diameter": attr.int(doc = "Clock tree synthesis sink group desired diamater in microns"),
         "min_pin_distance": attr.string(doc = "The minimum distance in microns between pins around the outside of the block."),
+        "enable_improve_placement": attr.bool(default=True, doc = "Enable/Disable improve_placement pass.")
     },
 )

--- a/place_and_route/private/resize.bzl
+++ b/place_and_route/private/resize.bzl
@@ -51,7 +51,7 @@ def resize(ctx, open_road_info):
         ),
     ] + placement_padding_struct.commands + [
         "detailed_placement",
-        "improve_placement",
+        "improve_placement" if ctx.attr.enable_improve_placement else "",
         "optimize_mirroring",
         "check_placement -verbose",
         "report_checks -path_delay min_max -format full_clock_expanded -fields {input_pin slew capacitance} -digits 3",


### PR DESCRIPTION
This adds new `enable_improve_placement` attr to `place_and_route` rule.
`improve_placement` pass breaks some of the designs,
so having option to  disable is beneficial for some users.
Default behavior remains unchanged.

First part of the #243 PR.