### PR TITLE
place_and_route: detailed_routing: Add reports

### DIFF
--- a/place_and_route/private/detailed_routing.bzl
+++ b/place_and_route/private/detailed_routing.bzl
@@ -74,6 +74,24 @@ def detailed_routing(ctx, open_road_info):
                                   "\n}")
         open_road_commands.append("density_fill -rules {}".format(density_fill_config.path))
         inputs.append(density_fill_config)
+
+    open_road_commands.append("puts \"report_checks -path_delay min_max -format full_clock_expanded -fields {input_pin slew capacitance} -digits 3\"")
+    open_road_commands.append("report_checks -path_delay min_max -format full_clock_expanded -fields {input_pin slew capacitance} -digits 3")
+
+    open_road_commands.append("puts \"report_wns\"")
+    open_road_commands.append("report_wns")
+
+    open_road_commands.append("puts \"report_tns\"")
+    open_road_commands.append("report_tns")
+
+    open_road_commands.append("puts \"report_check_types -max_slew -max_capacitance -max_fanout -violators\"")
+    open_road_commands.append("report_check_types -max_slew -max_capacitance -max_fanout -violators")
+
+    open_road_commands.append("puts \"report_floating_nets -verbose\"")
+    open_road_commands.append("report_floating_nets -verbose")
+
+    open_road_commands.append("puts \"report_units\"")
+    open_road_commands.append("report_units")
     open_road_commands.append("write_def {}".format(routed_def.path))
 
     execution_requirements = {}


### PR DESCRIPTION
It would be nice to have additional reports after detailed routing is finished.
This PR adds those in `detailed_routing` step. Report commands are similar to the ones in [global_routing](https://github.com/hdl/bazel_rules_hdl/blob/main/place_and_route/private/global_routing.bzl#L67-L72) step.
This is part of https://github.com/hdl/bazel_rules_hdl/pull/243 and https://github.com/google/xls/issues/1226

@mithro please take a look