### PR TITLE
P&R: Run estimate_parasitics before clock repair

### DIFF
--- a/place_and_route/private/clock_tree_synthesis.bzl
+++ b/place_and_route/private/clock_tree_synthesis.bzl
@@ -47,6 +47,7 @@ def clock_tree_synthesis(ctx, open_road_info):
             sink_clustering_max_diameter = "-sink_clustering_max_diameter {}".format(ctx.attr.sink_clustering_max_diameter) if ctx.attr.sink_clustering_max_diameter else "",
         ),
         "set_propagated_clock [all_clocks]",
+        "estimate_parasitics -placement",
         "repair_clock_nets",
         "estimate_parasitics -placement",
     ] + placement_padding_struct.commands + [


### PR DESCRIPTION
This commit adds parasitic estimation after `clock_tree_synthesis` and
before `repair_clock_nets`. This pass is also run in the ORFS.

Third part of the #243 