### PR TITLE
P&R: Move `remove_buffers` pass to floorplan stage

### DIFF
--- a/place_and_route/private/floorplan.bzl
+++ b/place_and_route/private/floorplan.bzl
@@ -91,6 +91,7 @@ def init_floor_plan(ctx):
         "source {tracks_file}".format(
             tracks_file = open_road_configuration.tracks_file.path,
         ),
+        "remove_buffers",
         "insert_tiecells {port} -prefix \"TIE_ONE_\"".format(
             port = tieoneport,
         ),

--- a/place_and_route/private/global_placement.bzl
+++ b/place_and_route/private/global_placement.bzl
@@ -40,7 +40,6 @@ def global_placement(ctx, open_road_info):
             pad_left = open_road_configuration.global_placement_cell_pad,
             pad_right = open_road_configuration.global_placement_cell_pad,
         ),
-        "remove_buffers",
     ]
 
     command_output = openroad_command(


### PR DESCRIPTION
Move `remove_buffers` pass to run just after floorplan initialization
It `remove_buffers` should only remove clock/data buffers
added by synthesis process. Changing order may affect designs.

Fifth part of the #243 