### PR TITLE
Synthesis: Use ABC script from ORFS

### DIFF
--- a/synthesis/BUILD
+++ b/synthesis/BUILD
@@ -22,6 +22,7 @@ package(
 )
 
 exports_files(["synth.tcl"])
+exports_files(["abc.script"])
 
 pkg_tar(
     name = "yosys",

--- a/synthesis/abc.script
+++ b/synthesis/abc.script
@@ -1,0 +1,45 @@
+&get -n
+&st
+&dch
+&nf
+&put
+&get -n
+&st
+&syn2
+&if -g -K 6
+&synch2
+&nf
+&put
+&get -n
+&st
+&syn2
+&if -g -K 6
+&synch2
+&nf
+&put
+&get -n
+&st
+&syn2
+&if -g -K 6
+&synch2
+&nf
+&put
+&get -n
+&st
+&syn2
+&if -g -K 6
+&synch2
+&nf
+&put
+&get -n
+&st
+&syn2
+&if -g -K 6
+&synch2
+&nf
+&put
+buffer -c
+topo
+stime -c
+upsize -c
+dnsize -c

--- a/synthesis/build_defs.bzl
+++ b/synthesis/build_defs.bzl
@@ -90,6 +90,7 @@ def _synthesize_design_impl(ctx):
     default_liberty_file = ctx.attr.standard_cells[StandardCellInfo].default_corner.liberty
 
     synth_tcl = ctx.file.synth_tcl
+    abc_script = ctx.file.abc_script
 
     inputs = []
     inputs.extend(verilog_files)
@@ -97,6 +98,7 @@ def _synthesize_design_impl(ctx):
     inputs.append(uhdm_flist)
     inputs.extend(uhdm_files)
     inputs.append(synth_tcl)
+    inputs.append(abc_script)
     inputs.append(default_liberty_file)
 
     (tool_inputs, input_manifests) = ctx.resolve_tools(tools = [ctx.attr.yosys_tool])
@@ -125,6 +127,7 @@ def _synthesize_design_impl(ctx):
         "OUTPUT": output_file,
         "LIBERTY": default_liberty_file,
         "DONT_USE_ARGS": dont_use_args,
+        "ABC_SCRIPT": abc_script,
     }
 
     if ctx.attr.target_clock_period_pico_seconds:
@@ -252,6 +255,11 @@ synthesize_rtl = rule(
             default = Label("//synthesis:synth.tcl"),
             allow_single_file = True,
             doc = "Tcl synthesis script compatible with the environment-variable API of synth.tcl",
+        ),
+        "abc_script": attr.label(
+            default = Label("//synthesis:abc.script"),
+            allow_single_file = True,
+            doc = "ABC script",
         ),
         "target_clock_period_pico_seconds": attr.int(doc = "target clock period in picoseconds"),
         "output_file_name": attr.string(doc = "The output file name."),

--- a/synthesis/synth.tcl
+++ b/synthesis/synth.tcl
@@ -77,9 +77,9 @@ set liberty $::env(LIBERTY)
 dfflibmap -liberty $liberty
 
 if { [info exists ::env(CLOCK_PERIOD) ] } {
-  abc -liberty $liberty -dff -g aig -D $::env(CLOCK_PERIOD) {*}$::env(DONT_USE_ARGS)
+  abc -liberty $liberty -dff -script $::env(ABC_SCRIPT) -g aig -D $::env(CLOCK_PERIOD) {*}$::env(DONT_USE_ARGS)
 } else {
-  abc -liberty $liberty -dff -g aig {*}$::env(DONT_USE_ARGS)
+  abc -liberty $liberty -dff -script $::env(ABC_SCRIPT) -g aig {*}$::env(DONT_USE_ARGS)
 }
 
 # Remove internal only aliases for public nets and then give created instances


### PR DESCRIPTION
This commit adds abc script from ORFS as a default abc script.
User can provide custom script using `abc_script` attr in the `synthesize_rtl` rule.
This is not a default yosys abc script, so it may cause some issues with existing flows.

Eighth part of the #243 