### PR TITLE
Don't rely on escapes for spaces in logging tcl command

### DIFF
--- a/synthesis/synth.tcl
+++ b/synthesis/synth.tcl
@@ -117,7 +117,7 @@ if { [info exists ::env(STATS_JSON) ] } {
 read_liberty -lib -ignore_miss_func $liberty
 ltp -noff $top
 
-yosys log -n Flop count:\
+yosys log -n "Flop count: "
 yosys select -count t:*__df* t:DFF* t:*_DFF* t:*_SDFF* t:*_ADFF* t:*dff
 
 set base_liberty [file tail $liberty]


### PR DESCRIPTION
A yosys log command used an escape to print a trailing space. This could cause issues if the trailing space was removed by code-cleanup tools. Instead quote the logged string.