### PR TITLE
Adding `-ffp-contract=off` flag.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 build --cxxopt "-std=c++17"
+build --cxxopt "-ffp-contract=off"
 build --host_cxxopt "-std=c++17"
+build --host_cxxopt "-ffp-contract=off"
 build --crosstool_top=@llvm_toolchain//:toolchain
 
 build:ciremotebuild --crosstool_top=@llvm_toolchain//:toolchain

--- a/dependency_support/org_theopenroadproject/build_helper.bzl
+++ b/dependency_support/org_theopenroadproject/build_helper.bzl
@@ -92,6 +92,7 @@ OPENROAD_BINARY_SRCS = OPENROAD_BINARY_SRCS_WITHOUT_MAIN + [
 
 OPENROAD_COPTS = [
     "-fexceptions",
+    "-ffp-contract=off", # Needed for floating point stability.
     "-Wno-error",
     "-Wall",
     "-Wextra",


### PR DESCRIPTION
This is needed for floating point stability.

The global placement depends on the output of the FFT library. Without `-ffp-contract=off` the current FFT library produces different results dependent on if the compiler is targeting an x86 architecture which has the "FMA instruction".

The FMA instruction omits the rounding done in the multiplication instruction, making the calculations produce different results for some input values

See https://kristerw.github.io/2021/11/09/fp-contract/

See also OpenROAD change @
https://github.com/The-OpenROAD-Project/OpenROAD/pull/4518