### PR TITLE
verilator: Add `pic_static_library ` to output files

### DIFF
--- a/verilator/defs.bzl
+++ b/verilator/defs.bzl
@@ -67,6 +67,8 @@ def cc_compile_and_link_static_library(ctx, srcs, hdrs, deps, runfiles, includes
     )
 
     output_files = []
+    if linking_output.library_to_link.pic_static_library != None:
+        output_files.append(linking_output.library_to_link.pic_static_library)
     if linking_output.library_to_link.static_library != None:
         output_files.append(linking_output.library_to_link.static_library)
     if linking_output.library_to_link.dynamic_library != None:


### PR DESCRIPTION
This turns
```
$ bazelisk-linux-amd64 cquery --output=files '//hardware:rv32_verilator'
INFO: Analyzed target //hardware:rv32_verilator (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
INFO: Elapsed time: 0.091s, Critical Path: 0.00s
INFO: 0 processes.
INFO: Build completed successfully, 0 total actions
```
into
```
$ bazelisk-linux-amd64 cquery --output=files '//hardware:rv32_verilator'
INFO: Analyzed target //hardware:rv32_verilator (6 packages loaded, 1150 targets configured).
INFO: Found 1 target...
bazel-out/k8-fastbuild/bin/hardware/librv32_verilator.a
INFO: Elapsed time: 1.237s, Critical Path: 0.00s
INFO: 0 processes.
INFO: Build completed successfully, 0 total actions
```
for me.
