### PR TITLE
verilator: Output generated headers

### DIFF
--- a/verilator/defs.bzl
+++ b/verilator/defs.bzl
@@ -157,7 +157,7 @@ def _verilator_cc_library(ctx):
     defines = ["VM_TRACE"] if ctx.attr.trace else []
     deps = [ctx.attr._verilator_lib, ctx.attr._zlib, ctx.attr._verilator_svdpi]
 
-    return cc_compile_and_link_static_library(
+    [default, cc] = cc_compile_and_link_static_library(
         ctx,
         srcs = [verilator_output_cpp],
         hdrs = [verilator_output_hpp],
@@ -166,6 +166,7 @@ def _verilator_cc_library(ctx):
         includes = [verilator_output_hpp.path],
         deps = deps,
     )
+    return [default, cc, OutputGroupInfo(hdrs = depset([verilator_output_hpp]))]
 
 verilator_cc_library = rule(
     implementation = _verilator_cc_library,
@@ -223,6 +224,7 @@ verilator_cc_library = rule(
     provides = [
         CcInfo,
         DefaultInfo,
+        OutputGroupInfo,
     ],
     toolchains = [
         "@bazel_tools//tools/cpp:toolchain_type",


### PR DESCRIPTION
The generated headers are tracked through the `CcInfo` provider. This pull request adds the generated header files to the `files` field of the `DefaultInfo` provider.

In our case, we want to use the generated headers and verilated library outside of bazel. In other words, we want a the generated headers to be exposed as output files for a target.

I'm not sure if `verilated.h` and its dependencies should be packed in here as well, so I left it out for this PR.

Please don't hesitate to reach out!