### PR TITLE
Adds verilog hdrs to bazel rules

### DIFF
--- a/synthesis/build_defs.bzl
+++ b/synthesis/build_defs.bzl
@@ -65,6 +65,8 @@ def _synthesize_design_impl(ctx):
     transitive_srcs = _transitive_srcs([dep for dep in ctx.attr.deps if VerilogInfo in dep])
     verilog_srcs = [verilog_info_struct.srcs for verilog_info_struct in transitive_srcs.to_list()]
     verilog_files = [src for sub_tuple in verilog_srcs for src in sub_tuple]
+    verilog_hdrs = [verilog_info_struct.hdrs for verilog_info_struct in transitive_srcs.to_list()]
+    verilog_hdr_files = [hdr for sub_tuple in verilog_hdrs for hdr in sub_tuple]
 
     verilog_flist = _create_flist(
         ctx,
@@ -94,6 +96,7 @@ def _synthesize_design_impl(ctx):
 
     inputs = []
     inputs.extend(verilog_files)
+    inputs.extend(verilog_hdr_files)
     inputs.append(verilog_flist)
     inputs.append(uhdm_flist)
     inputs.extend(uhdm_files)

--- a/verilog/providers.bzl
+++ b/verilog/providers.bzl
@@ -38,6 +38,7 @@ def make_dag_entry(srcs, hdrs, deps, label):
 
     Args:
       srcs: A list of File that are 'srcs'.
+      hdrs: A list of File that are 'hdrs'.
       deps: A list of Label that are deps of this entry.
       label: A Label to use as the name for this entry.
     Returns:

--- a/verilog/providers.bzl
+++ b/verilog/providers.bzl
@@ -24,7 +24,7 @@ VerilogInfo = provider(
     },
 )
 
-def make_dag_entry(srcs, deps, label):
+def make_dag_entry(srcs, hdrs, deps, label):
     """Create a new DAG entry for use in VerilogInfo.
 
     As VerilogInfo should be created via 'merge_verilog_info' (rather than directly),
@@ -45,6 +45,7 @@ def make_dag_entry(srcs, deps, label):
     """
     return struct(
         srcs = tuple(srcs),
+        hdrs = tuple(hdrs),
         deps = tuple(deps),
         label = label,
     )
@@ -89,6 +90,7 @@ def _produce_dag_impl(ctx):
     verilog_info = make_verilog_info(
         new_entries = [make_dag_entry(
             srcs = ctx.files.srcs,
+            hdrs = ctx.files.hdrs,
             deps = ctx.attr.deps,
             label = ctx.label,
         )],
@@ -102,6 +104,7 @@ def _produce_dag_impl(ctx):
 verilog_library = rule(
     attrs = {
         "srcs": attr.label_list(allow_files = True),
+        "hdrs": attr.label_list(allow_files = True),
         "deps": attr.label_list(providers = [
             VerilogInfo,
         ]),


### PR DESCRIPTION
verilog_library now includes a hdrs attribute for include directives.