### PR TITLE
Fix flop count in synth.tcl

### DIFF
--- a/synthesis/synth.tcl
+++ b/synthesis/synth.tcl
@@ -131,7 +131,7 @@ read_liberty -lib -ignore_miss_func $liberty
 ltp -noff $top
 
 yosys log -n "Flop count: "
-yosys select -count t:*__df* t:DFF* t:*_DFF* t:*_SDFF* t:*_ADFF* t:*dff
+yosys select -count t:*__df* t:DF* t:*_DFF* t:*_SDFF* t:*_ADFF* t:*dff
 
 set base_liberty [file tail $liberty]
 yosys log Liberty: $base_liberty


### PR DESCRIPTION
Fix one glob used to match flops in the default synth.tcl flow; previously excluded flops in some PDKs.