### PR TITLE
Adds support for default driving cell in ABC

### DIFF
--- a/pdk/build_defs.bzl
+++ b/pdk/build_defs.bzl
@@ -25,6 +25,7 @@ StandardCellInfo = provider(
         "ha_fa_mapping": "HA/FA techmapping file",
         "parasitic_extraction_benchmark": "Optional calibration file for OpenRCX.",
         "open_road_configuration": "OpenROAD PDK configuration.",
+        "default_input_driver_cell": "The cell to assume is driving primary input nets (very useful for synthesis)",
     },
 )
 

--- a/synthesis/build_defs.bzl
+++ b/synthesis/build_defs.bzl
@@ -112,7 +112,7 @@ def _synthesize_design_impl(ctx):
 
     constr = ctx.actions.declare_file("{}_abc_constraints.constr".format(ctx.attr.name))
     constr_contents = ""
-    default_driver_cell = ctx.attr.standard_cells[StandardCellInfo].default_input_driver_cell
+    default_driver_cell = getattr(ctx.attr.standard_cells[StandardCellInfo], "default_input_driver_cell", "")
     if default_driver_cell:
         constr_contents = "set_driving_cell {}\n".format(default_driver_cell)
 

--- a/synthesis/build_defs.bzl
+++ b/synthesis/build_defs.bzl
@@ -110,6 +110,15 @@ def _synthesize_design_impl(ctx):
 
     log_file = ctx.actions.declare_file("{}_yosys_output.log".format(ctx.attr.name))
 
+    constr = ctx.actions.declare_file("{}_abc_constraints.constr".format(ctx.attr.name))
+    constr_contents = ""
+    default_driver_cell = ctx.attr.standard_cells[StandardCellInfo].default_input_driver_cell
+    if default_driver_cell:
+        constr_contents = "set_driving_cell {}\n".format(default_driver_cell)
+
+    ctx.actions.write(constr, constr_contents)
+    inputs.append(constr)
+
     args = ctx.actions.args()
     args.add("-q")  # quiet mode only errors printed to stderr
     args.add("-q")  # second q don't print warnings
@@ -131,6 +140,7 @@ def _synthesize_design_impl(ctx):
         "LIBERTY": default_liberty_file,
         "DONT_USE_ARGS": dont_use_args,
         "ABC_SCRIPT": abc_script,
+        "CONSTR": constr,
     }
 
     if ctx.attr.target_clock_period_pico_seconds:

--- a/synthesis/synth.tcl
+++ b/synthesis/synth.tcl
@@ -90,9 +90,9 @@ dfflibmap -liberty $liberty
 opt
 
 if { [info exists ::env(CLOCK_PERIOD) ] } {
-  abc -showtmp -nocleanup -liberty $liberty -dff -script $::env(ABC_SCRIPT) -constr $::env(CONSTR) -g aig -D $::env(CLOCK_PERIOD) {*}$::env(DONT_USE_ARGS)
+  abc -liberty $liberty -dff -script $::env(ABC_SCRIPT) -constr $::env(CONSTR) -g aig -D $::env(CLOCK_PERIOD) {*}$::env(DONT_USE_ARGS)
 } else {
-  abc -showtmp -nocleanup -liberty $liberty -dff -script $::env(ABC_SCRIPT) -constr $::env(CONSTR) -g aig {*}$::env(DONT_USE_ARGS)
+  abc -liberty $liberty -dff -script $::env(ABC_SCRIPT) -constr $::env(CONSTR) -g aig {*}$::env(DONT_USE_ARGS)
 }
 
 setundef -zero

--- a/synthesis/synth.tcl
+++ b/synthesis/synth.tcl
@@ -90,9 +90,9 @@ dfflibmap -liberty $liberty
 opt
 
 if { [info exists ::env(CLOCK_PERIOD) ] } {
-  abc -liberty $liberty -dff -script $::env(ABC_SCRIPT) -g aig -D $::env(CLOCK_PERIOD) {*}$::env(DONT_USE_ARGS)
+  abc -showtmp -nocleanup -liberty $liberty -dff -script $::env(ABC_SCRIPT) -constr $::env(CONSTR) -g aig -D $::env(CLOCK_PERIOD) {*}$::env(DONT_USE_ARGS)
 } else {
-  abc -liberty $liberty -dff -script $::env(ABC_SCRIPT) -g aig {*}$::env(DONT_USE_ARGS)
+  abc -showtmp -nocleanup -liberty $liberty -dff -script $::env(ABC_SCRIPT) -constr $::env(CONSTR) -g aig {*}$::env(DONT_USE_ARGS)
 }
 
 setundef -zero


### PR DESCRIPTION
If no default driving cell is provided primary inputs are assumed to have infinite drive strength in ABC. This leads to very poor STA performance out of synthesis.