### PR TITLE
$(PYTHON3) Make variable substitution is not supported in run_shell and is not needed anyway.

### DIFF
--- a/gds_write/build_defs.bzl
+++ b/gds_write/build_defs.bzl
@@ -72,8 +72,7 @@ def _gds_write_impl(ctx):
                 tech_lef,
             ],
         ),
-        command = "$(PYTHON3)" +
-                  " {}".format(ctx.executable._gds_write.path) +
+        command = "{}".format(ctx.executable._gds_write.path) +
                   " --design-name {}".format(ctx.attr.implemented_rtl[SynthesisInfo].top_module) +
                   " --input-def {}".format(ctx.attr.implemented_rtl[OpenRoadInfo].routed_def.path) +
                   lef_args +


### PR DESCRIPTION
Tested: modify xls to pull from this git and `bazel build -c opt //xls/modules/rle:rle_dec_gds_sky130`