### PR TITLE
Rename `exec_tools` attributes to `tools` for genrules

### DIFF
--- a/dependency_support/at_clifford_icestorm/bundled.BUILD.bazel
+++ b/dependency_support/at_clifford_icestorm/bundled.BUILD.bazel
@@ -57,7 +57,7 @@ py_binary(
     srcs = [],
     outs = ["chipdb-%s.txt" % device],
     cmd = "$(location :icebox_chipdb) %s > $@" % ICE40_DEVICES[device],
-    exec_tools = [":icebox_chipdb"],
+    tools = [":icebox_chipdb"],
     visibility = ["//visibility:public"],
 ) for device in ICE40_DEVICES.keys()]
 
@@ -143,5 +143,5 @@ py_binary(
     srcs = ["icefuzz/timings_%s.txt" % chip],
     outs = ["generated/timings_%s.cc" % chip],
     cmd = "(dir=$$(pwd) && cd $$(dirname $(location :icefuzz/timings_%s.txt)) && $$dir/$(location :timings) %s) > $@" % (chip, chip),
-    exec_tools = [":timings"],
+    tools = [":timings"],
 ) for chip in CHIPS]

--- a/dependency_support/com_github_yosyshq_nextpnr/bundled.BUILD.bazel
+++ b/dependency_support/com_github_yosyshq_nextpnr/bundled.BUILD.bazel
@@ -199,7 +199,7 @@ py_binary(
     ],
     outs = ["generated/ecp5_chipdb_%s.bba" % device],
     cmd = "PRJTRELLIS_DB=$$(dirname '$(location @com_github_yosyshq_prjtrellis_db//:devices.json)') $(location :trellis_import) -p $(location ecp5/constids.inc) -g $(location ecp5/gfx.h) %s > $@" % device,
-    exec_tools = [":trellis_import"],
+    tools = [":trellis_import"],
 ) for device in ECP5_DEVICES]
 
 [genrule(
@@ -207,7 +207,7 @@ py_binary(
     srcs = ["generated/ecp5_chipdb_%s.bba" % device],
     outs = ["generated/ecp5_chipdb_%s.cc" % device],
     cmd = "$(location :bbasm) --c %s $(SRCS) $@" % BBASM_ENDIAN_FLAG,
-    exec_tools = [":bbasm"],
+    tools = [":bbasm"],
 ) for device in ECP5_DEVICES]
 
 cc_library(
@@ -271,7 +271,7 @@ py_binary(
         ICE40_CHIPDB_OPTS[device],
         device,
     ),
-    exec_tools = [":ice40_chipdb_py"],
+    tools = [":ice40_chipdb_py"],
 ) for device in ICE40_DEVICES]
 
 [genrule(
@@ -279,7 +279,7 @@ py_binary(
     srcs = ["generated/ice40_chipdb_%s.bba" % device],
     outs = ["generated/ice40_chipdb_%s.cc" % device],
     cmd = "$(location :bbasm) --c %s $(SRCS) $@" % BBASM_ENDIAN_FLAG,
-    exec_tools = [":bbasm"],
+    tools = [":bbasm"],
 ) for device in ICE40_DEVICES]
 
 cc_library(

--- a/dependency_support/org_theopenroadproject/bundled.BUILD.bazel
+++ b/dependency_support/org_theopenroadproject/bundled.BUILD.bazel
@@ -152,7 +152,7 @@ genrule(
     ],
     outs = ["src/stt/src/flt/etc/POST9.cpp"],
     cmd = "$(location @tk_tcl//:tclsh) $(location src/stt/src/flt/etc/MakeDatVar.tcl) post9 \"$@\" $(location src/stt/src/flt/etc/POST9.dat)",
-    exec_tools = ["@tk_tcl//:tclsh"],
+    tools = ["@tk_tcl//:tclsh"],
 )
 
 genrule(
@@ -163,7 +163,7 @@ genrule(
     ],
     outs = ["src/stt/src/flt/etc/POWV9.cpp"],
     cmd = "$(location @tk_tcl//:tclsh) $(location src/stt/src/flt/etc/MakeDatVar.tcl) powv9 \"$@\" $(location src/stt/src/flt/etc/POWV9.dat)",
-    exec_tools = ["@tk_tcl//:tclsh"],
+    tools = ["@tk_tcl//:tclsh"],
 )
 
 cc_library(


### PR DESCRIPTION
`exec_tools` is not an attribute of [genrule](https://bazel.build/reference/be/general#genrule). It should instead be replaced by `tools`.
