### PR TITLE
Avoid duplicate `liblib` prefix for `verilator` target.

### DIFF
--- a/dependency_support/verilator/verilator.BUILD
+++ b/dependency_support/verilator/verilator.BUILD
@@ -188,7 +188,7 @@ cc_library(
 )
 
 cc_library(
-    name = "libverilator",
+    name = "verilator",
     srcs = [
         "include/gtkwave/fastlz.h",
         "include/gtkwave/fst_config.h",
@@ -232,6 +232,15 @@ cc_library(
     deps = [
         "@net_zlib//:zlib",
     ],
+)
+
+# This alias is for supporting the legacy name but while allowing the
+# `cc_library` target to be renamed to avoid a `liblibverilator.a`
+# output name.
+alias(
+    name = "libverilator",
+    actual = "verilator",
+    visibility = ["//visibility:public"],
 )
 
 cc_library(


### PR DESCRIPTION
The default uses of `cc_common.create_cc_toolchain_config_info.artifact_name_patterns` on unix systems prefix static libs with `lib`. So by naming a `cc_library` `lib*` the output file will get a `liblib` prefix. E.g.

```
bazel-out/k8-fastbuild/bin/external/verilator/liblibverilator.a
```

This change fixes this issue but adds an alias for backward compatibility.