### PR TITLE
Added incompatibility flag to prepare for flip in future Bazel versions

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -39,6 +39,13 @@ test:ciremotebuild --build_metadata=VISIBILITY=PUBLIC
 test:ciremotebuild --remote_timeout=3600
 
 ###############################################################################
+## Incompatibility flags
+###############################################################################
+
+# https://github.com/bazelbuild/bazel/issues/8195
+build --incompatible_disallow_empty_glob=true
+
+###############################################################################
 ## User flags
 ###############################################################################
 # Optionally allow users to define custom flags when developing new features.

--- a/dependency_support/at_clifford_yosys/bundled.BUILD.bazel
+++ b/dependency_support/at_clifford_yosys/bundled.BUILD.bazel
@@ -173,7 +173,6 @@ cc_library(
             "backends/**/*.h",
             "frontends/**/*.h",
             "passes/**/*.h",
-            "techlibs/**/*.h",
         ],
         exclude = [
             "backends/protobuf/*.h",

--- a/dependency_support/com_github_ninja_build_ninja/bundled.BUILD.bazel
+++ b/dependency_support/com_github_ninja_build_ninja/bundled.BUILD.bazel
@@ -58,12 +58,3 @@ cc_binary(
     ],
     visibility = ["//visibility:public"],
 )
-
-# Expose prebuilt binaries for opensourced projects that require them to build.
-filegroup(
-    name = "ninja_binaries",
-    srcs = glob(["files/bin/**"]) + [
-        "README.md",
-    ],
-    visibility = ["//visibility:public"],
-)

--- a/dependency_support/com_github_quantamhd_lemon/bundled.BUILD.bazel
+++ b/dependency_support/com_github_quantamhd_lemon/bundled.BUILD.bazel
@@ -35,9 +35,7 @@ genrule(
 
 cc_library(
     name = "lemon",
-    srcs = glob([
-        "lemon/*.c",
-    ]) + [
+    srcs = [
       "lemon/arg_parser.cc",
       "lemon/random.cc",
       "lemon/base.cc",

--- a/dependency_support/com_github_yosyshq_nextpnr/bundled.BUILD.bazel
+++ b/dependency_support/com_github_yosyshq_nextpnr/bundled.BUILD.bazel
@@ -145,6 +145,7 @@ cc_binary(
             "tests/%s/*.h" % family,
         ],
         exclude = TEXTUAL_HDRS,
+        allow_empty = True,
     ),
     copts = COPTS,
     defines = DEFINES + [

--- a/dependency_support/com_github_yosyshq_prjtrellis_db/bundled.BUILD.bazel
+++ b/dependency_support/com_github_yosyshq_prjtrellis_db/bundled.BUILD.bazel
@@ -21,7 +21,6 @@ exports_files([
     "LICENSE",
 ] + glob([
     "ECP5/**/*",
-    "ECP5/*",
 ]))
 
 filegroup(

--- a/dependency_support/com_google_ortools/com_google_ortools.bzl
+++ b/dependency_support/com_google_ortools/com_google_ortools.bzl
@@ -25,6 +25,11 @@ def com_google_ortools():
         strip_prefix = "or-tools-9.7",
         urls = ["https://github.com/google/or-tools/archive/refs/tags/v9.7.tar.gz"],
         sha256 = "054d9517fc6c83f15150c93ef1c2c674ffd7d4a0d1fdc78f6ef8bc3e25c2e339",
+        patch_args = ["-p1"],
+        patches = [
+            # TODO: Newer versions of ortools should not need this patch
+            Label("//dependency_support/com_google_ortools:scip.patch"),
+        ],
     )
     maybe(
         new_git_repository,

--- a/dependency_support/com_google_ortools/scip.patch
+++ b/dependency_support/com_google_ortools/scip.patch
@@ -1,0 +1,12 @@
+diff --git a/bazel/scip.BUILD b/bazel/scip.BUILD
+index a0e1c17b5b..a516de7617 100644
+--- a/bazel/scip.BUILD
++++ b/bazel/scip.BUILD
+@@ -82,7 +82,6 @@ cc_library(
+             "src/*/*.hpp",
+             "src/scip/githash.c",
+             "src/scip/sorttpl.c",
+-            "src/scip/buildflags.c",
+         ],
+         exclude =
+         [

--- a/dependency_support/com_opencircuitdesign_magic/bundled.BUILD.bazel
+++ b/dependency_support/com_opencircuitdesign_magic/bundled.BUILD.bazel
@@ -105,7 +105,6 @@ cc_library(
         "plow/*.c",
         "resis/*.c",
         "router/*.c",
-        "scmos/*.c",
         "select/*.c",
         "sim/*.c",
         "textio/*.c",

--- a/dependency_support/net_invisible_island_ncurses/bundled.BUILD.bazel
+++ b/dependency_support/net_invisible_island_ncurses/bundled.BUILD.bazel
@@ -118,7 +118,6 @@ cc_library(
             "ncurses/tinfo/*.c",
             "ncurses/trace/*.c",
             "ncurses/tty/*.c",
-            "build_sources/*.c",
         ],
         exclude = glob([
             "ncurses/base/lib_driver.c",
@@ -127,8 +126,6 @@ cc_library(
             "ncurses/tinfo/tinfo_driver.c",
             "ncurses/tinfo/make_hash.c",
             "ncurses/report_offsets.c",
-            "ncurses/*_test.c",
-            "build_sources/*_test.c",
         ]),
     ) + [
         # Generated files are not found by glob.

--- a/dependency_support/net_sourceforge_ngspice/bundled.BUILD.bazel
+++ b/dependency_support/net_sourceforge_ngspice/bundled.BUILD.bazel
@@ -79,12 +79,15 @@ COPTS = ["-w"]
 
 [genrule(
     name = "%s_cmextrn_h" % subdir,
-    srcs = glob([
-        "src/xspice/icm/%s/modpath.lst" % subdir,
-        "src/xspice/icm/%s/udnpath.lst" % subdir,
-        "src/xspice/icm/%s/**/*.ifs" % subdir,
-        "src/xspice/icm/%s/**/*.c" % subdir,
-    ]),
+    srcs = glob(
+        [
+            "src/xspice/icm/%s/modpath.lst" % subdir,
+            "src/xspice/icm/%s/udnpath.lst" % subdir,
+            "src/xspice/icm/%s/**/*.ifs" % subdir,
+            "src/xspice/icm/%s/**/*.c" % subdir,
+        ],
+        allow_empty = True,
+    ),
     outs = [
         "src/xspice/icm/%s/cmextrn.h" % subdir,
         "src/xspice/icm/%s/cminfo.h" % subdir,
@@ -140,7 +143,6 @@ cc_library(
     name = "libngspice",
     srcs = glob([
         "src/**/*.c",
-        "src/spicelib/parser/inpptree-parser.c",
     ], exclude = [
         "**/test_*.c",
         "src/main.c",

--- a/dependency_support/org_fftw/bundled.BUILD.bazel
+++ b/dependency_support/org_fftw/bundled.BUILD.bazel
@@ -113,14 +113,11 @@ filegroup(
         [
             "api/*.c",
             "api/*.h",
-            "cell/*.c",
-            "cell/*.h",
             "dft/*.c",
             "dft/*.h",
             "dft/scalar/*.c",
             "dft/scalar/*.h",
             "dft/scalar/*/*.c",
-            "dft/scalar/*/*.h",
             "kernel/*.c",
             "kernel/*.h",
             "rdft/*.c",
@@ -128,7 +125,6 @@ filegroup(
             "rdft/scalar/*.c",
             "rdft/scalar/*.h",
             "rdft/scalar/*/*.c",
-            "rdft/scalar/*/*.h",
             "reodft/*.c",
             "reodft/*.h",
         ],
@@ -220,9 +216,7 @@ fftw_arch_copts = select({
 filegroup(
     name = "fftw_extra_simd_srcs",
     srcs = glob([
-        "dft/simd/*.c",
         "dft/simd/*.h",
-        "rdft/simd/*.c",
         "rdft/simd/*.h",
         "simd-support/*.c",
         "simd-support/*.h",

--- a/dependency_support/org_gnu_bison/bison_empty_glob.patch
+++ b/dependency_support/org_gnu_bison/bison_empty_glob.patch
@@ -1,0 +1,13 @@
+diff --git a/bison/internal/gnulib/gnulib.BUILD b/bison/internal/gnulib/gnulib.BUILD
+index 9ee0b51..84fcf5e 100644
+--- a/bison/internal/gnulib/gnulib.BUILD
++++ b/bison/internal/gnulib/gnulib.BUILD
+@@ -118,7 +118,7 @@ _GNULIB_SRCS = glob([
+     "lib/xmalloc.c",
+     "lib/xmemdup0.c",
+     "lib/xstrndup.c",
+-])
++], allow_empty = True)
+ 
+ _GNULIB_DARWIN_SRCS = []
+ 

--- a/dependency_support/org_gnu_bison/org_gnu_bison.bzl
+++ b/dependency_support/org_gnu_bison/org_gnu_bison.bzl
@@ -30,4 +30,9 @@ def org_gnu_bison():
         name = "rules_bison",
         sha256 = "2279183430e438b2dc77cacd7b1dbb63438971b2411406570f1ddd920b7c9145",
         urls = ["https://github.com/jmillikin/rules_bison/releases/download/v0.2.2/rules_bison-v0.2.2.tar.xz"],
+        patch_args = ["-p1"],
+        patches = [
+            # TODO(https://github.com/jmillikin/rules_bison/pull/14): Delete after this PR is merged
+            Label("//dependency_support/org_gnu_bison:bison_empty_glob.patch"),
+        ],
     )

--- a/dependency_support/org_theopenroadproject/bundled.BUILD.bazel
+++ b/dependency_support/org_theopenroadproject/bundled.BUILD.bazel
@@ -92,6 +92,7 @@ cc_library(
             "src/gui/src/stub_heatMap.cpp",
         ],
         exclude = OPENROAD_LIBRARY_SRCS_EXCLUDE,
+        allow_empty = True,
     ) + [
         "src/stt/src/flt/etc/POST9.cpp",
         "src/stt/src/flt/etc/POWV9.cpp",
@@ -122,6 +123,7 @@ cc_library(
             "src/gui/src/stub_heatMap.cpp",
         ],
         exclude = OPENROAD_LIBRARY_SRCS_EXCLUDE,
+        allow_empty = True,
     ) + [
         "src/stt/src/flt/etc/POST9.cpp",
         "src/stt/src/flt/etc/POWV9.cpp",
@@ -968,7 +970,6 @@ cc_library(
         "src/odb/src/db/*.h",
         "src/odb/src/db/*.hpp",
         "src/odb/src/zutil/*.cpp",
-        "src/odb/src/zlib/*.cpp",
         "src/odb/src/defout/*.cpp",
         "src/odb/src/defout/*.h",
         "src/odb/src/defin/*.cpp",
@@ -976,8 +977,6 @@ cc_library(
         "src/odb/src/lefin/*.cpp",
         "src/odb/src/lefin/*.h",
         "src/odb/src/lefout/*.cpp",
-        "src/odb/src/lefout/*.h",
-        "src/odb/src/tm/*.cpp",
     ]),
     hdrs = glob([
         "src/odb/include/odb/*.h",

--- a/dependency_support/org_theopenroadproject/org_theopenroadproject.bzl
+++ b/dependency_support/org_theopenroadproject/org_theopenroadproject.bzl
@@ -22,6 +22,9 @@ def org_theopenroadproject():
         new_git_repository,
         name = "org_theopenroadproject",
         commit = "f6da0454e350e93c62264f7b7c95029e1ad2b9fd",
+        # TODO: Convert to http_archive whenever there is an archive
+        # which contains submodules.
+        # https://github.com/dear-github/dear-github/issues/214
         init_submodules = True,
         remote = "https://github.com/The-OpenROAD-Project/OpenROAD.git",
         build_file = Label("@rules_hdl//dependency_support/org_theopenroadproject:bundled.BUILD.bazel"),

--- a/dependency_support/org_theopenroadproject_asap7sc6t_26/bundled.BUILD.bazel
+++ b/dependency_support/org_theopenroadproject_asap7sc6t_26/bundled.BUILD.bazel
@@ -229,6 +229,7 @@ asap7_srams_files(
     name = "asap7-srams-sc6t_rev26",
     rev = "26",
     tracks = "6t",
+    has_gds = False,
 )
 
 # FIXME: Where is the 1x techlef?

--- a/dependency_support/org_theopenroadproject_asap7sc7p5t_27/bundled.BUILD.bazel
+++ b/dependency_support/org_theopenroadproject_asap7sc7p5t_27/bundled.BUILD.bazel
@@ -364,6 +364,7 @@ asap7_srams_files(
     name = "asap7-srams-sc7p5t_rev27",
     rev = "27",
     tracks = "7p5t",
+    has_gds = False,
 )
 
 # FIXME: Where is the 1x techlef?


### PR DESCRIPTION
A quick query seemed to prove the repo is compliant with `incompatible_disallow_empty_glob` but it'd be good to add regardless to avoid future regressions.

closes https://github.com/hdl/bazel_rules_hdl/issues/344