### PR TITLE
Replace Verilator repository rule with simple http_archive

### DIFF
--- a/dependency_support/verilator/private/BUILD.bazel
+++ b/dependency_support/verilator/private/BUILD.bazel
@@ -7,7 +7,25 @@ py_binary(
 )
 
 py_binary(
+    name = "verilator_bisonpre",
+    srcs = ["verilator_bisonpre.py"],
+    visibility = ["@verilator//:__pkg__"],
+)
+
+py_binary(
+    name = "verilator_build_template",
+    srcs = ["verilator_build_template.py"],
+    visibility = ["@verilator//:__pkg__"],
+)
+
+py_binary(
     name = "verilator_flexfix",
     srcs = ["verilator_flexfix.py"],
+    visibility = ["@verilator//:__pkg__"],
+)
+
+py_binary(
+    name = "verilator_version",
+    srcs = ["verilator_version.py"],
     visibility = ["@verilator//:__pkg__"],
 )

--- a/dependency_support/verilator/private/verilator_bisonpre.py
+++ b/dependency_support/verilator/private/verilator_bisonpre.py
@@ -1,0 +1,23 @@
+"""A wrapper for bisonpre that reduces noise in console logs."""
+
+import subprocess
+import sys
+
+
+def main() -> None:
+    """The main entrypoint"""
+    result = subprocess.run(
+        [sys.executable] + sys.argv[1:],
+        check=False,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        encoding="utf-8",
+    )
+    # Only log if the process has failed.
+    if result.returncode:
+        print(result.stdout, file=sys.stderr)
+        sys.exit(result.returncode)
+
+
+if __name__ == "__main__":
+    main()

--- a/dependency_support/verilator/private/verilator_build_template.py
+++ b/dependency_support/verilator/private/verilator_build_template.py
@@ -1,0 +1,63 @@
+"""A tool for generating Verilator source files required for compilation"""
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict
+
+
+def _substitutions_arg(value: str) -> Dict[str, str]:
+    return json.loads(value)
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments"""
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--version",
+        type=Path,
+        required=True,
+        help="A file containing the current Verilator version.",
+    )
+
+    parser.add_argument(
+        "--substitutions",
+        type=_substitutions_arg,
+        required=True,
+        help="Substitutions to apply to the template file.",
+    )
+
+    parser.add_argument(
+        "--template",
+        type=Path,
+        required=True,
+        help="The template file to be updated.",
+    )
+
+    parser.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="The expected output files.",
+    )
+
+    return parser.parse_args()
+
+
+def main() -> None:
+    """The main entrypoint"""
+    args = parse_args()
+
+    version = args.version.read_text(encoding="utf-8").strip()
+
+    content = args.template.read_text(encoding="utf-8")
+    for key, value in args.substitutions.items():
+        value = value.replace("{VERILATOR_VERSION}", version)
+        content = content.replace(key, value)
+
+    args.output.write_text(content, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/dependency_support/verilator/private/verilator_version.py
+++ b/dependency_support/verilator/private/verilator_version.py
@@ -1,0 +1,52 @@
+"""A tool for parsing the current Verilator version from a Verilator change log."""
+
+import argparse
+import re
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments"""
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--changelog",
+        type=Path,
+        required=True,
+        help="The path to the verilator changelog.",
+    )
+
+    parser.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="The expected output files.",
+    )
+
+    return parser.parse_args()
+
+
+def main() -> None:
+    """The main entrypoint"""
+    args = parse_args()
+
+    version = None
+    for line in args.changelog.read_text(encoding="utf-8").splitlines():
+        match = re.match(
+            r"^Verilator ([\d\.]+) \d\d\d\d-\d\d-\d\d",
+            line,
+        )
+        if match:
+            version = match.group(1)
+            break
+
+    if not version:
+        raise ValueError(
+            f"Could not detect verilator version from changelog: {args.changelog}"
+        )
+
+    args.output.write_text(version, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/dependency_support/verilator/verilator.BUILD.bazel
+++ b/dependency_support/verilator/verilator.BUILD.bazel
@@ -13,16 +13,17 @@
 # Original implementation by Kevin Kiningham (@kkiningh) in kkiningh/rules_verilator.
 # Ported to bazel_rules_hdl by Stephen Tridgell (@stridge-cruxml)
 
-load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("@rules_hdl//dependency_support/com_github_westes_flex:flex.bzl", "genlex")
 load(
     "@rules_hdl//dependency_support/verilator/private:verilator_utils.bzl",
     "verilator_astgen",
     "verilator_bisonpre",
+    "verilator_build_template",
     "verilator_flexfix",
+    "verilator_version",
 )
-load("@rules_python//python:defs.bzl", "py_binary")
 
 package(default_visibility = ["//visibility:private"])
 
@@ -34,18 +35,50 @@ exports_files([
     "COPYING.LESSER",
 ])
 
-# `py_binary` does not accept sources that do not end in `.py`. So to
-# successfully turn `bisonpre` into a binary, the source needs to be renamed.
-copy_file(
-    name = "bisonpre_src",
-    src = "src/bisonpre",
-    out = "src/bisonpre.py",
+verilator_version(
+    name = "version",
+    changelog = "Changes",
 )
 
-py_binary(
-    name = "bisonpre",
-    srcs = ["src/bisonpre.py"],
-    main = "src/bisonpre.py",
+verilator_build_template(
+    name = "config_package",
+    out = "src/config_package.h",
+    substitutions = {
+        "#define PACKAGE_STRING \"\"": "#define PACKAGE_STRING \"Verilator v{VERILATOR_VERSION}\"",
+    },
+    template = "src/config_package.h.in",
+    version = ":version",
+)
+
+write_file(
+    name = "config_rev_template",
+    out = "src/config_rev.h.in",
+    content = """\
+static const char* const DTVERSION_rev = "";
+
+""".splitlines(),
+    newline = "unix",
+)
+
+verilator_build_template(
+    name = "config_rev",
+    out = "src/config_rev.h",
+    substitutions = {
+        "DTVERSION_rev = \"\"": "DTVERSION_rev = \"v{VERILATOR_VERSION}\"",
+    },
+    template = "src/config_rev.h.in",
+    version = ":version",
+)
+
+verilator_build_template(
+    name = "verilated_config",
+    out = "include/verilated_config.h",
+    substitutions = {
+        "@PACKAGE_NAME@": "Verilator",
+        "@PACKAGE_VERSION@": "{VERILATOR_VERSION}",
+    },
+    template = "include/verilated_config.h.in",
+    version = ":version",
 )
 
 verilator_astgen(
@@ -168,7 +201,7 @@ verilator_bisonpre(
         "$(execpath V3ParseBison.c)",
         "$(execpath src/verilog.y)",
     ],
-    bisonpre = ":bisonpre",
+    bisonpre = "src/bisonpre",
     env = {
         "BISON_PKGDATADIR": "$(execpath @org_gnu_bison//:data)",
         "M4": "$(execpath @org_gnu_m4//:m4)",
@@ -285,7 +318,6 @@ cc_library(
     includes = ["include"],
     linkopts = [
         "-lpthread",
-        "-latomic",
     ],
     strip_include_prefix = "include/",
     textual_hdrs = [


### PR DESCRIPTION
This way users can more comfortably override the `@verilator` repository to apply custom patches without needing to re-implement how to compile Verilator.