### PR TITLE
Split out resize place and route step to repair and resize

### DIFF
--- a/place_and_route/build_defs.bzl
+++ b/place_and_route/build_defs.bzl
@@ -24,6 +24,7 @@ load("//place_and_route:private/global_placement.bzl", "global_placement")
 load("//place_and_route:private/global_routing.bzl", "global_routing")
 load("//place_and_route:private/pdn_gen.bzl", "pdn_gen")
 load("//place_and_route:private/place_pins.bzl", "place_pins")
+load("//place_and_route:private/repair.bzl", "repair")
 load("//place_and_route:private/resize.bzl", "resize")
 load("//synthesis:build_defs.bzl", "SynthesisInfo")
 
@@ -32,6 +33,7 @@ PLACE_AND_ROUTE_STEPS = [
     ("place_pins", place_pins, ""),
     ("pdn_gen", pdn_gen, ""),
     ("global_placement", global_placement, "global_placement"),
+    ("repair", repair, ""),
     ("resize", resize, ""),
     ("clock_tree_synthesis", clock_tree_synthesis, ""),
     ("global_routing", global_routing, "post_pnr"),

--- a/place_and_route/private/resize.bzl
+++ b/place_and_route/private/resize.bzl
@@ -15,7 +15,6 @@
 """Resize openROAD commands"""
 
 load("//place_and_route:open_road.bzl", "OpenRoadInfo", "merge_open_road_info", "openroad_command", "placement_padding_commands")
-load("//synthesis:build_defs.bzl", "SynthesisInfo")
 
 def resize(ctx, open_road_info):
     """Performs resizing operation of the standard cells.

--- a/place_and_route/private/resize.bzl
+++ b/place_and_route/private/resize.bzl
@@ -14,7 +14,6 @@
 
 """Resize openROAD commands"""
 
-load("@rules_hdl//pdk:open_road_configuration.bzl", "get_open_road_configuration")
 load("//place_and_route:open_road.bzl", "OpenRoadInfo", "merge_open_road_info", "openroad_command", "placement_padding_commands")
 load("//synthesis:build_defs.bzl", "SynthesisInfo")
 

--- a/place_and_route/private/resize.bzl
+++ b/place_and_route/private/resize.bzl
@@ -15,7 +15,7 @@
 """Resize openROAD commands"""
 
 load("@rules_hdl//pdk:open_road_configuration.bzl", "get_open_road_configuration")
-load("//place_and_route:open_road.bzl", "OpenRoadInfo", "format_openroad_do_not_use_list", "merge_open_road_info", "openroad_command", "placement_padding_commands", "timing_setup_commands")
+load("//place_and_route:open_road.bzl", "OpenRoadInfo", "merge_open_road_info", "openroad_command", "placement_padding_commands")
 load("//synthesis:build_defs.bzl", "SynthesisInfo")
 
 def resize(ctx, open_road_info):

--- a/place_and_route/private/resize.bzl
+++ b/place_and_route/private/resize.bzl
@@ -29,8 +29,6 @@ def resize(ctx, open_road_info):
        open_road_info: OpenRoadInfo provider from a previous step.
 
     """
-    open_road_configuration = get_open_road_configuration(ctx.attr.synthesized_rtl[SynthesisInfo])
-
     placement_padding_struct = placement_padding_commands(ctx)
 
     inputs = placement_padding_struct.inputs


### PR DESCRIPTION
This enables stopping before detailed placement easily, which is useful for certain flows.