### PR TITLE
Remove uses of ctx.resolve_tools(...).

### DIFF
--- a/dependency_support/org_theopenroadproject/tcl_encode.bzl
+++ b/dependency_support/org_theopenroadproject/tcl_encode.bzl
@@ -23,8 +23,6 @@ def _tcl_encode_impl(ctx):
     outfile_name = ctx.attr.out if ctx.attr.out else ctx.attr.name + ".cc"
     output_file = ctx.actions.declare_file(outfile_name)
 
-    (inputs, _) = ctx.resolve_tools(tools = [ctx.attr._tclsh, ctx.attr._encode_script])
-
     args = ctx.actions.args()
     args.add(ctx.file._encode_script)
     args.add(output_file)
@@ -35,7 +33,7 @@ def _tcl_encode_impl(ctx):
         outputs = [output_file],
         inputs = ctx.files.srcs,
         arguments = [args],
-        tools = inputs,
+        tools = [ctx.executable._tclsh, ctx.file._encode_script],
         executable = ([file for file in ctx.files._tclsh if file.basename == "tclsh"][0]),
     )
     return [DefaultInfo(files = depset([output_file]))]
@@ -61,7 +59,7 @@ tcl_encode = rule(
         ),
         "_tclsh": attr.label(
             default = "@tk_tcl//:tclsh",
-            allow_files = True,
+            executable = True,
             cfg = "exec",
         ),
     },

--- a/dependency_support/org_theopenroadproject/tcl_wrap_cc.bzl
+++ b/dependency_support/org_theopenroadproject/tcl_wrap_cc.bzl
@@ -56,8 +56,6 @@ def _tcl_wrap_cc_impl(ctx):
     outfile_name = ctx.attr.out if ctx.attr.out else ctx.attr.name + ".cc"
     output_file = ctx.actions.declare_file(outfile_name)
 
-    (inputs, _) = ctx.resolve_tools(tools = [ctx.attr._swig])
-
     include_root_directory = root_label.workspace_root + "/" + root_label.package
 
     src_inputs = _get_transative_srcs(ctx.files.srcs + ctx.files.root_swig_src, ctx.attr.deps)
@@ -87,7 +85,7 @@ def _tcl_wrap_cc_impl(ctx):
         outputs = [output_file],
         inputs = src_inputs,
         arguments = [args],
-        tools = inputs,
+        tools = ctx.files._swig,
         executable = ([file for file in ctx.files._swig if file.basename == "swig"][0]),
     )
     return [

--- a/flows/flows.bzl
+++ b/flows/flows.bzl
@@ -169,9 +169,6 @@ flow_binary = rule(
 )
 
 def _run_step_with_inputs(ctx, step, inputs_dict, outputs_step_dict):
-    # inputs and output manifests are for the runfiles of the step executable.
-    (tool_inputs, input_manifests) = ctx.resolve_tools(tools = [step])
-
     # The inputs_env and inputs handle the named inputs of the step.
     inputs = []
     inputs_env = {}
@@ -208,11 +205,10 @@ def _run_step_with_inputs(ctx, step, inputs_dict, outputs_step_dict):
         outputs = outputs,
         inputs = inputs,
         command = step[DefaultInfo].files_to_run.executable.path,
-        tools = tool_inputs,
+        tools = [step.files_to_run],
         arguments = step[FlowStepInfo].arguments,
         mnemonic = step[FlowStepInfo].executable_type,
         env = dicts.add(constants_env, inputs_env, outputs_env),
-        input_manifests = input_manifests,
         toolchain = None,
     )
 

--- a/place_and_route/open_road.bzl
+++ b/place_and_route/open_road.bzl
@@ -229,7 +229,6 @@ def openroad_command(ctx, commands, input_db = None, step_name = None, inputs = 
     command_file = ctx.actions.declare_file(file_name)
     ctx.actions.write(command_file, content = "\n".join(real_commands))
 
-    (tool_inputs, input_manifests) = ctx.resolve_tools(tools = [ctx.attr._openroad])
     openroad_runfiles_dir = ctx.executable._openroad.path + ".runfiles"
 
     log_file = ctx.actions.declare_file(
@@ -253,8 +252,6 @@ def openroad_command(ctx, commands, input_db = None, step_name = None, inputs = 
             command_file.path,
         ],
         executable = ctx.executable._openroad,
-        tools = tool_inputs,
-        input_manifests = input_manifests,
         env = {
             "QT_QPA_PLATFORM": ctx.attr.qt_qpa_platform,
             "TCL_LIBRARY": openroad_runfiles_dir + "/tk_tcl/library",

--- a/static_timing/build_defs.bzl
+++ b/static_timing/build_defs.bzl
@@ -34,7 +34,6 @@ def _run_opensta_impl(ctx):
     if default_liberty_file in additional_liberty_files:
         additional_liberty_files.remove(default_liberty_file)
 
-    (tool_inputs, input_manifests) = ctx.resolve_tools(tools = [ctx.attr._opensta])
     opensta_runfiles_dir = ctx.executable._opensta.path + ".runfiles"
 
     sta_tcl = ctx.file.sta_tcl
@@ -51,11 +50,9 @@ def _run_opensta_impl(ctx):
 
     ctx.actions.run(
         outputs = [sta_log],
-        inputs = tool_inputs.to_list() + [default_liberty_file, sta_tcl, netlist] + additional_liberty_files,
+        inputs = [default_liberty_file, sta_tcl, netlist] + additional_liberty_files,
         arguments = ["-exit", sta_tcl.path],
         executable = ctx.executable._opensta,
-        tools = tool_inputs,
-        input_manifests = input_manifests,
         env = env,
         mnemonic = "RunningSTA",
         toolchain = None,

--- a/synthesis/build_defs.bzl
+++ b/synthesis/build_defs.bzl
@@ -108,8 +108,6 @@ def _synthesize_design_impl(ctx):
     inputs.append(default_liberty_file)
     inputs.extend(additional_liberty_files)
 
-    (tool_inputs, input_manifests) = ctx.resolve_tools(tools = [ctx.attr.yosys_tool])
-
     yosys_runfiles_dir = ctx.executable.yosys_tool.path + ".runfiles"
 
     log_file = ctx.actions.declare_file("{}_yosys_output.log".format(ctx.attr.name))
@@ -180,11 +178,9 @@ def _synthesize_design_impl(ctx):
 
     ctx.actions.run(
         outputs = [output_file, log_file],
-        inputs = inputs + tool_inputs.to_list(),
+        inputs = inputs,
         arguments = [args],
         executable = ctx.executable.yosys_tool,
-        tools = tool_inputs,
-        input_manifests = input_manifests,
         env = env,
         mnemonic = "SynthesizingRTL",
         toolchain = None,


### PR DESCRIPTION
This API will be removed from a future Bazel version.

Instead, the `executable` or `tools` argument to `ctx.actions.run` and `ctx.actions.run_shell` should be used.