### PR TITLE
Remove noise from the PerformancePowerAreaProto package name.

### DIFF
--- a/place_and_route/private/benchmark.bzl
+++ b/place_and_route/private/benchmark.bzl
@@ -63,7 +63,7 @@ def benchmark(ctx, open_road_info):
 
     cmds = [
         "echo \"# proto-file: synthesis/performance_power_area.proto\" >> {out};".format(out = benchmark_path),
-        "echo \"# proto-message: bazel_rules_hdl.ppa.PerformancePowerAreaProto\n\" >> {out};".format(out = benchmark_path),
+        "echo \"# proto-message: hdl.ppa.PerformancePowerAreaProto\n\" >> {out};".format(out = benchmark_path),
     ]
     prefix = "metric=$(cat {log} | awk ".format(log = command_output.log_file.path)
     suffix = "; echo \"{field} $metric\" >> {out};"

--- a/synthesis/build_defs.bzl
+++ b/synthesis/build_defs.bzl
@@ -224,7 +224,7 @@ def _benchmark_synth(ctx, synth_log_file):
 
     cmds = [
         "echo \"# proto-file: synthesis/performance_power_area.proto\" >> {out};".format(out = benchmark_path),
-        "echo \"# proto-message: bazel_rules_hdl.ppa.PerformancePowerAreaProto\n\" >> {out};".format(out = benchmark_path),
+        "echo \"# proto-message: hdl.ppa.PerformancePowerAreaProto\n\" >> {out};".format(out = benchmark_path),
     ]
     prefix = "metric=$({cat} {log} | awk ".format(cat = cat, log = synth_log_file.path)
     suffix = "; echo \"{field} $metric\" >> {out};"

--- a/synthesis/performance_power_area.proto
+++ b/synthesis/performance_power_area.proto
@@ -1,6 +1,6 @@
 syntax = "proto2";
 
-package bazel_rules_hdl.ppa;
+package hdl.ppa;
 
 message PerformancePowerAreaProto {
   // ====== Performance ======


### PR DESCRIPTION
Put it in hdl.ppa.PerformancePowerAreaProto.

A proto package name is meant to provide a namespace for the proto-buffer and should not necessarily indicate specific filename path elements.

Previously, the package sounded like it is specifically tied to bazel_rules_hdl; but it has nothing to do with bazel rules, just a way to express data in the context of hdl.

Let's keep it simple and just call the package 'hdl.ppa'.