### PR TITLE
Fix namespace of PdkInfoProto to better reflect the intent.

### DIFF
--- a/pdk/proto/pdk_info.proto
+++ b/pdk/proto/pdk_info.proto
@@ -1,6 +1,6 @@
 syntax = "proto2";
 
-package bazel_rules_hdl.pdk;
+package hdl.pdk;
 
 message PdkInfoProto {
   repeated string cell_lef_paths = 1;


### PR DESCRIPTION
Namespaces for protocol buffers should not be based on path-elements but primarily on what they represent.
This proto has nothing to do with bazel nor rules, just hdl.