### PR TITLE
Update example WORKSPACE contents in the README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ maybe(
     sha256 = rules_hdl_git_sha256,
     strip_prefix = "bazel_rules_hdl-%s" % rules_hdl_git_hash,
     urls = [
-        "https://github.com/hdl/bazel_rules_hdl/archive/%s.tar.gz" % git_hash,
+        "https://github.com/hdl/bazel_rules_hdl/archive/%s.tar.gz" % rules_hdl_git_hash,
     ],
 )
 


### PR DESCRIPTION
Small fix in sample WORKSPACE addition.

It would be useful to have a real complete WORKSPACE file, perhaps in a `bazel_rules_hdl_example` repo, tested nightly, that users could use as a starting point for their own RTL builds.
