### PR TITLE
Fix reproducibility of external repositories

### DIFF
--- a/dependency_support/boost/boost.bzl
+++ b/dependency_support/boost/boost.bzl
@@ -14,17 +14,17 @@
 
 """Registers Bazel workspaces for the Boost C++ libraries."""
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
 def boost():
     maybe(
-        git_repository,
+        http_archive,
         name = "com_github_nelhage_rules_boost",
         # This equivalent to boost 1.82
-        commit = "1217caae292dc9f14e8109777ba43c988cf89c5b",
-        remote = "https://github.com/nelhage/rules_boost",
-        shallow_since = "1640124117 -0800",
+        urls = ["https://github.com/nelhage/rules_boost/archive/1217caae292dc9f14e8109777ba43c988cf89c5b.zip"],
+        strip_prefix = "rules_boost-1217caae292dc9f14e8109777ba43c988cf89c5b",
+        integrity = "sha256-dBOuD+owIZaNbz07AXJJmwdPYcZsQU54rD/s+D8VL/I=",
         patches = [
             # rules_boost does not include Boost Python, see
             # https://github.com/nelhage/rules_boost/issues/67

--- a/dependency_support/com_google_protobuf/com_google_protobuf.bzl
+++ b/dependency_support/com_google_protobuf/com_google_protobuf.bzl
@@ -14,15 +14,16 @@
 
 """Registers Bazel workspaces for the GNU readline library."""
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
 def com_google_protobuf():
     maybe(
-        git_repository,
+        http_archive,
         name = "com_google_protobuf",
-        tag = "v23.3",
-        patches = ["@com_google_ortools//patches:protobuf-v23.3.patch"],
+        urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v23.3/protobuf-23.3.tar.gz"],
+        strip_prefix = "protobuf-23.3",
+        integrity = "sha256-Ol9HrTqhAZLFV3/whrJLlzmjaTfDTOq225EqFqPvf44=",
         patch_args = ["-p1"],
-        remote = "https://github.com/protocolbuffers/protobuf.git",
+        patches = ["@com_google_ortools//patches:protobuf-v23.3.patch"],
     )


### PR DESCRIPTION
These are the same pins but use `http_archive` in order to benefit from the use of repository caches.