### PR TITLE
Added `verilator_toolchain` rule.

### DIFF
--- a/dependency_support/dependency_support.bzl
+++ b/dependency_support/dependency_support.bzl
@@ -66,8 +66,13 @@ load("@rules_hdl//dependency_support/rules_license:rules_license.bzl", "rules_li
 load("@rules_hdl//dependency_support/tk_tcl:tk_tcl.bzl", "tk_tcl")
 load("@rules_hdl//dependency_support/verilator:verilator.bzl", "verilator")
 
-def dependency_support():
-    """ Registers dependencies """
+# buildifier: disable=unnamed-macro
+def dependency_support(register_toolchains = True):
+    """Registers dependencies
+
+    Args:
+        register_toolchains (bool, optional): Register rules_hdl toolchains.
+    """
     at_clifford_icestorm()
     at_clifford_yosys()
     bazel_skylib()
@@ -115,3 +120,6 @@ def dependency_support():
     rules_license()
     tk_tcl()
     verilator()
+
+    if register_toolchains:
+        native.register_toolchains(str(Label("//verilator:verilator_toolchain")))

--- a/verilator/BUILD.bazel
+++ b/verilator/BUILD.bazel
@@ -12,7 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load(":defs.bzl", "verilator_toolchain")
+
 package(
     default_applicable_licenses = ["//:package_license"],
     default_visibility = ["//visibility:private"],
+)
+
+toolchain_type(
+    name = "toolchain_type",
+    visibility = ["//visibility:public"],
+)
+
+verilator_toolchain(
+    name = "verilator_toolchain_impl",
+    verilator = "@verilator//:verilator_executable",
+    deps = [
+        "@net_zlib//:zlib",
+        "@verilator//:libverilator",
+        "@verilator//:svdpi",
+    ],
+)
+
+toolchain(
+    name = "verilator_toolchain",
+    toolchain = ":verilator_toolchain_impl",
+    toolchain_type = ":toolchain_type",
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This change adds a `verilator_toolchain` rule that can be used to share Verilator inputs to compile actions across different rules.