### PR TITLE
Fix 'dependency checking of directories is unsound' warning

### DIFF
--- a/dependency_support/org_gnu_bison/bundled.BUILD.bazel
+++ b/dependency_support/org_gnu_bison/bundled.BUILD.bazel
@@ -42,9 +42,11 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-exports_files([
-    "data",
-])
+alias(
+    name = "data",
+    actual = ":bison_runtime_data",
+    visibility = ["//visibility:public"],
+)
 
 cc_library(
     name = "bison_src_headers",

--- a/dependency_support/verilator/verilator.BUILD.bazel
+++ b/dependency_support/verilator/verilator.BUILD.bazel
@@ -186,7 +186,6 @@ verilator_bisonpre(
     name = "verilator_bison",
     srcs = [
         "src/verilog.y",
-        "@org_gnu_bison//:data",
     ],
     outs = [
         "V3ParseBison.c",
@@ -202,8 +201,8 @@ verilator_bisonpre(
         "$(execpath src/verilog.y)",
     ],
     bisonpre = "src/bisonpre",
+    bison_data = "@org_gnu_bison//:bison_runtime_data",
     env = {
-        "BISON_PKGDATADIR": "$(execpath @org_gnu_bison//:data)",
         "M4": "$(execpath @org_gnu_m4//:m4)",
     },
     tools = [


### PR DESCRIPTION
Addresses the following warning whenever building Verilator.
```
WARNING: /home/user/.cache/bazel/_bazel_user/52140892d57e43aa70ce978171477bb4/external/verilator/BUILD.bazel:185:19: input 'data' to @@verilator//:verilator_bison is a directory; dependency checking of directories is unsound
```