### PR TITLE
ortools: Update to version 9.10

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+common --noexperimental_enable_bzlmod
+
 build --cxxopt "-std=c++17"
 build --cxxopt "-ffp-contract=off"
 build --host_cxxopt "-std=c++17"

--- a/dependency_support/com_google_absl/com_google_absl.bzl
+++ b/dependency_support/com_google_absl/com_google_absl.bzl
@@ -14,15 +14,15 @@
 
 """Registers Bazel workspaces for the GNU readline library."""
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
 def com_google_absl():
     maybe(
-        git_repository,
+        new_git_repository,
         name = "com_google_absl",
-        tag = "20230125.3",
-        patches = ["@com_google_ortools//patches:abseil-cpp-20230125.3.patch"],
+        tag = "20240116.2",
+        patches = ["@com_google_ortools//patches:abseil-cpp-20240116.2.patch"],
         patch_args = ["-p1"],
         remote = "https://github.com/abseil/abseil-cpp.git",
     )

--- a/dependency_support/com_google_ortools/com_google_ortools.bzl
+++ b/dependency_support/com_google_ortools/com_google_ortools.bzl
@@ -22,23 +22,23 @@ def com_google_ortools():
     maybe(
         http_archive,
         name = "com_google_ortools",
-        strip_prefix = "or-tools-9.7",
-        urls = ["https://github.com/google/or-tools/archive/refs/tags/v9.7.tar.gz"],
-        sha256 = "054d9517fc6c83f15150c93ef1c2c674ffd7d4a0d1fdc78f6ef8bc3e25c2e339",
+        strip_prefix = "or-tools-9.10",
+        urls = ["https://github.com/google/or-tools/archive/refs/tags/v9.10.tar.gz"],
+        sha256 = "e7c27a832f3595d4ae1d7e53edae595d0347db55c82c309c8f24227e675fd378",
     )
     maybe(
         new_git_repository,
         name = "scip",
-        build_file = "@com_google_ortools//bazel:scip.BUILD",
-        patches = ["@com_google_ortools//bazel:scip.patch"],
+        build_file = "@com_google_ortools//bazel:scip.BUILD.bazel",
+        patches = ["@com_google_ortools//bazel:scip-v900.patch"],
         patch_args = ["-p1"],
-        tag = "v803",
+        tag = "v900",
         remote = "https://github.com/scipopt/scip.git",
     )
     maybe(
         http_archive,
         name = "bliss",
-        build_file = "@com_google_ortools//bazel:bliss.BUILD",
+        build_file = "@com_google_ortools//bazel:bliss.BUILD.bazel",
         patches = ["@com_google_ortools//bazel:bliss-0.73.patch"],
         sha256 = "f57bf32804140cad58b1240b804e0dbd68f7e6bf67eba8e0c0fa3a62fd7f0f84",
         url = "https://github.com/google/or-tools/releases/download/v9.0/bliss-0.73.zip",

--- a/dependency_support/com_google_protobuf/com_google_protobuf.bzl
+++ b/dependency_support/com_google_protobuf/com_google_protobuf.bzl
@@ -21,9 +21,9 @@ def com_google_protobuf():
     maybe(
         http_archive,
         name = "com_google_protobuf",
-        urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v23.3/protobuf-23.3.tar.gz"],
-        strip_prefix = "protobuf-23.3",
-        integrity = "sha256-Ol9HrTqhAZLFV3/whrJLlzmjaTfDTOq225EqFqPvf44=",
+        urls = ["https://github.com/protocolbuffers/protobuf/archive/refs/tags/v26.1.tar.gz"],
+        strip_prefix = "protobuf-26.1",
+        sha256 = "4fc5ff1b2c339fb86cd3a25f0b5311478ab081e65ad258c6789359cd84d421f8",
         patch_args = ["-p1"],
-        patches = ["@com_google_ortools//patches:protobuf-v23.3.patch"],
+        patches = ["@com_google_ortools//patches:protobuf-v26.1.patch"],
     )


### PR DESCRIPTION
Resolves https://github.com/hdl/bazel_rules_hdl/issues/310.

Needs
```
diff --git a/.bazelrc b/.bazelrc
index f104dd2..dafdb4f 100644
--- a/.bazelrc
+++ b/.bazelrc
@@ -48,3 +48,5 @@ test:ciremotebuild --remote_timeout=3600
 # with flags defined in this file.
 #
 try-import %workspace$/user.bazelrc
+
+common --noenable_bzlmod
```

when compiling with `7.1.2`, but judging by https://github.com/hdl/bazel_rules_hdl/pull/325#issuecomment-2108406030, CI seems to be on an older bazel release?