### PR TITLE
Unconditionally read liberty files in every step of place_and_route.

### DIFF
--- a/place_and_route/open_road.bzl
+++ b/place_and_route/open_road.bzl
@@ -233,10 +233,6 @@ def openroad_command(ctx, commands, input_db = None, step_name = None, inputs = 
     real_commands.extend(commands)
     real_commands.append("write_db {}".format(output_db.path))
 
-    # This is here to make it easy to append to the input arguments of the run command.
-    # Otherwise it would fail when no input_db is provided.
-    input_db_dependency = [input_db] if input_db else []
-
     file_name = "{}_script.tcl".format(output_db.basename[:-(len(output_db.extension) + 1)])
     command_file = ctx.actions.declare_file(file_name)
     ctx.actions.write(command_file, content = "\n".join(real_commands))

--- a/place_and_route/private/benchmark.bzl
+++ b/place_and_route/private/benchmark.bzl
@@ -14,7 +14,7 @@
 
 """Benchmark OpenROAD commands"""
 
-load("//place_and_route:open_road.bzl", "OpenRoadInfo", "merge_open_road_info", "openroad_command", "timing_setup_commands")
+load("//place_and_route:open_road.bzl", "OpenRoadInfo", "merge_open_road_info", "openroad_command")
 
 def benchmark(ctx, open_road_info):
     """Benchmarks and reports metrics for a placed design.
@@ -28,11 +28,7 @@ def benchmark(ctx, open_road_info):
 
     """
 
-    timing_setup_command_struct = timing_setup_commands(ctx)
-
-    inputs = timing_setup_command_struct.inputs
-
-    open_road_commands = timing_setup_command_struct.commands + [
+    open_road_commands = [
         "report_power",
         "report_wns",
         "report_tns",
@@ -53,7 +49,7 @@ def benchmark(ctx, open_road_info):
         ctx,
         commands = open_road_commands,
         input_db = open_road_info.output_db,
-        inputs = inputs,
+        inputs = [],
         step_name = "benchmark",
         outputs = cmd_outputs,
     )
@@ -93,7 +89,7 @@ def benchmark(ctx, open_road_info):
 
     current_action_open_road_info = OpenRoadInfo(
         commands = open_road_commands,
-        input_files = depset(inputs),
+        input_files = depset(),
         output_db = command_output.db,
         benchmark_report = benchmark_report,
         logs = depset([command_output.log_file] + cmd_outputs),

--- a/place_and_route/private/clock_tree_synthesis.bzl
+++ b/place_and_route/private/clock_tree_synthesis.bzl
@@ -15,7 +15,7 @@
 """Clock Tree Synthesis openROAD commands"""
 
 load("//pdk:open_road_configuration.bzl", "get_open_road_configuration")
-load("//place_and_route:open_road.bzl", "OpenRoadInfo", "format_openroad_do_not_use_list", "merge_open_road_info", "openroad_command", "placement_padding_commands", "timing_setup_commands")
+load("//place_and_route:open_road.bzl", "OpenRoadInfo", "format_openroad_do_not_use_list", "merge_open_road_info", "openroad_command", "placement_padding_commands")
 load("//synthesis:defs.bzl", "SynthesisInfo")
 
 def clock_tree_synthesis(ctx, open_road_info):
@@ -32,12 +32,11 @@ def clock_tree_synthesis(ctx, open_road_info):
 
     open_road_configuration = get_open_road_configuration(ctx.attr.synthesized_rtl[SynthesisInfo])
 
-    timing_setup_command_struct = timing_setup_commands(ctx)
     placement_padding_struct = placement_padding_commands(ctx)
 
-    inputs = timing_setup_command_struct.inputs + placement_padding_struct.inputs
+    inputs = placement_padding_struct.inputs
 
-    open_road_commands = timing_setup_command_struct.commands + [
+    open_road_commands = [
         format_openroad_do_not_use_list(open_road_configuration.do_not_use_cell_list),
         "estimate_parasitics -placement",
         "repair_clock_inverters",

--- a/place_and_route/private/detailed_routing.bzl
+++ b/place_and_route/private/detailed_routing.bzl
@@ -15,7 +15,7 @@
 """Detailed Routing openROAD commands"""
 
 load("//pdk:open_road_configuration.bzl", "DetailedRoutingInfo", "get_open_road_configuration")
-load("//place_and_route:open_road.bzl", "OpenRoadInfo", "merge_open_road_info", "openroad_command", "timing_setup_commands")
+load("//place_and_route:open_road.bzl", "OpenRoadInfo", "merge_open_road_info", "openroad_command")
 load("//synthesis:defs.bzl", "SynthesisInfo")
 
 def detailed_routing(ctx, open_road_info):
@@ -30,8 +30,7 @@ def detailed_routing(ctx, open_road_info):
 
     """
 
-    timing_setup_command_struct = timing_setup_commands(ctx)
-    inputs = timing_setup_command_struct.inputs
+    inputs = []
 
     output_drc = ctx.actions.declare_file("{}_output_drc".format(ctx.attr.name))
     routed_def = ctx.actions.declare_file("{}_detail_routed.def".format(ctx.attr.name))
@@ -55,7 +54,7 @@ def detailed_routing(ctx, open_road_info):
         if detailed_routing_configs.enable_via_gen:
             detailed_routing_args += " -disable_via_gen "
 
-    open_road_commands = timing_setup_command_struct.commands + [
+    open_road_commands = [
         "set_propagated_clock [all_clocks]",
         "detailed_route -output_drc {} {}".format(output_drc.path, detailed_routing_args),
     ]

--- a/place_and_route/private/global_placement.bzl
+++ b/place_and_route/private/global_placement.bzl
@@ -15,7 +15,7 @@
 """Global placement openROAD commands"""
 
 load("//pdk:open_road_configuration.bzl", "get_open_road_configuration")
-load("//place_and_route:open_road.bzl", "OpenRoadInfo", "merge_open_road_info", "openroad_command", "timing_setup_commands")
+load("//place_and_route:open_road.bzl", "OpenRoadInfo", "merge_open_road_info", "openroad_command")
 load("//synthesis:defs.bzl", "SynthesisInfo")
 
 def global_placement(ctx, open_road_info):
@@ -30,11 +30,8 @@ def global_placement(ctx, open_road_info):
 
     """
     open_road_configuration = get_open_road_configuration(ctx.attr.synthesized_rtl[SynthesisInfo])
-    timing_setup_command_struct = timing_setup_commands(ctx)
 
-    inputs = timing_setup_command_struct.inputs
-
-    open_road_commands = timing_setup_command_struct.commands + [
+    open_road_commands = [
         "global_placement -timing_driven -routability_driven -density {density} -pad_left {pad_left} -pad_right {pad_right}".format(
             density = ctx.attr.placement_density,  #TODO(bazel): When bazel 4.0.0 is avaliable use float command
             pad_left = open_road_configuration.global_placement_cell_pad,
@@ -47,12 +44,12 @@ def global_placement(ctx, open_road_info):
         commands = open_road_commands,
         input_db = open_road_info.output_db,
         step_name = "global_placement",
-        inputs = inputs,
+        inputs = [],
     )
 
     global_place_open_road_info = OpenRoadInfo(
         commands = open_road_commands,
-        input_files = depset(inputs),
+        input_files = depset(),
         output_db = command_output.db,
         logs = depset([command_output.log_file]),
     )

--- a/place_and_route/private/global_routing.bzl
+++ b/place_and_route/private/global_routing.bzl
@@ -15,7 +15,7 @@
 """Global Routing openROAD commands"""
 
 load("//pdk:open_road_configuration.bzl", "get_open_road_configuration")
-load("//place_and_route:open_road.bzl", "OpenRoadInfo", "merge_open_road_info", "openroad_command", "timing_setup_commands")
+load("//place_and_route:open_road.bzl", "OpenRoadInfo", "merge_open_road_info", "openroad_command")
 load("//place_and_route:private/report_area.bzl", "generate_area_results")
 load("//place_and_route:private/report_power.bzl", "generate_power_results")
 load("//synthesis:defs.bzl", "SynthesisInfo")
@@ -43,13 +43,11 @@ def global_routing(ctx, open_road_info):
 
     """
     open_road_configuration = get_open_road_configuration(ctx.attr.synthesized_rtl[SynthesisInfo])
-    timing_setup_command_struct = timing_setup_commands(ctx)
-    inputs = timing_setup_command_struct.inputs
 
     general_routing_power_results = ctx.actions.declare_file("{}_general_routing_power_results.textproto".format(ctx.attr.name))
     general_routing_area_results = ctx.actions.declare_file("{}_general_routing_area_results.textproto".format(ctx.attr.name))
 
-    open_road_commands = timing_setup_command_struct.commands + [
+    open_road_commands = [
         """
 foreach layer_adjustment {global_routing_layer_adjustments} {{
     lassign $layer_adjustment layer adjustment
@@ -79,7 +77,7 @@ foreach layer_adjustment {global_routing_layer_adjustments} {{
         ctx,
         commands = open_road_commands,
         input_db = open_road_info.output_db,
-        inputs = inputs,
+        inputs = [],
         outputs = [
             general_routing_power_results,
             general_routing_area_results,
@@ -89,7 +87,7 @@ foreach layer_adjustment {global_routing_layer_adjustments} {{
 
     current_action_open_road_info = OpenRoadInfo(
         commands = open_road_commands,
-        input_files = depset(inputs),
+        input_files = depset(),
         output_db = command_output.db,
         logs = depset([command_output.log_file]),
         general_routing_power_results = general_routing_power_results,

--- a/place_and_route/private/place_pins.bzl
+++ b/place_and_route/private/place_pins.bzl
@@ -15,7 +15,7 @@
 """Pin Placement openROAD commands"""
 
 load("//pdk:open_road_configuration.bzl", "get_open_road_configuration")
-load("//place_and_route:open_road.bzl", "OpenRoadInfo", "merge_open_road_info", "openroad_command", "timing_setup_commands")
+load("//place_and_route:open_road.bzl", "OpenRoadInfo", "merge_open_road_info", "openroad_command")
 load("//synthesis:defs.bzl", "SynthesisInfo")
 
 def place_pins(ctx, open_road_info):
@@ -31,8 +31,7 @@ def place_pins(ctx, open_road_info):
     """
 
     open_road_configuration = get_open_road_configuration(ctx.attr.synthesized_rtl[SynthesisInfo])
-    timing_setup_command_struct = timing_setup_commands(ctx)
-    inputs = timing_setup_command_struct.inputs
+    inputs = []
 
     tapcell_command = "tapcell -distance {tapcell_distance} -tapcell_master {tapcell}".format(
         tapcell = open_road_configuration.tap_cell,
@@ -49,7 +48,7 @@ def place_pins(ctx, open_road_info):
         if ctx.file.pin_placement_script:
             inputs.append(ctx.file.pin_placement_script)
 
-    open_road_commands = timing_setup_command_struct.commands + [
+    open_road_commands = [
         "source {}".format(ctx.file.pin_placement_script.path) if ctx.file.pin_placement_script else "",
         "place_pins -hor_layers {hor_layers} -ver_layers {ver_layers} {min_pin_distance}".format(
             hor_layers = open_road_configuration.pin_horizontal_metal_layer,

--- a/place_and_route/private/repair.bzl
+++ b/place_and_route/private/repair.bzl
@@ -15,7 +15,7 @@
 """Repair openROAD commands"""
 
 load("//pdk:open_road_configuration.bzl", "get_open_road_configuration")
-load("//place_and_route:open_road.bzl", "OpenRoadInfo", "format_openroad_do_not_use_list", "merge_open_road_info", "openroad_command", "timing_setup_commands")
+load("//place_and_route:open_road.bzl", "OpenRoadInfo", "format_openroad_do_not_use_list", "merge_open_road_info", "openroad_command")
 load("//synthesis:defs.bzl", "SynthesisInfo")
 
 def repair(ctx, open_road_info):
@@ -31,11 +31,7 @@ def repair(ctx, open_road_info):
     """
     open_road_configuration = get_open_road_configuration(ctx.attr.synthesized_rtl[SynthesisInfo])
 
-    timing_setup_command_struct = timing_setup_commands(ctx)
-
-    inputs = timing_setup_command_struct.inputs
-
-    open_road_commands = timing_setup_command_struct.commands + [
+    open_road_commands = [
         format_openroad_do_not_use_list(open_road_configuration.do_not_use_cell_list),
         "estimate_parasitics -placement",
         "remove_buffers",
@@ -55,13 +51,13 @@ def repair(ctx, open_road_info):
         ctx,
         commands = open_road_commands,
         input_db = open_road_info.output_db,
-        inputs = inputs,
+        inputs = [],
         step_name = "repair",
     )
 
     current_action_open_road_info = OpenRoadInfo(
         commands = open_road_commands,
-        input_files = depset(inputs),
+        input_files = depset(),
         output_db = command_output.db,
         logs = depset([command_output.log_file]),
     )


### PR DESCRIPTION
OpenROAD can sometimes behave unexpectedly when reading design files before the library files. This change updates the flow such that `read_db` commands occur after `read_liberty` commands, and adds liberty file reading to every step. The majority of the flow steps required the liberty files to be loaded, so this also simplifies each bzl file slightly.