### PR TITLE
Pass the assumed IO loads as env vars into OpenROAD from the stdcell PDK.

### DIFF
--- a/place_and_route/open_road.bzl
+++ b/place_and_route/open_road.bzl
@@ -261,6 +261,8 @@ def openroad_command(ctx, commands, input_db = None, step_name = None, inputs = 
         ],
         executable = ctx.executable._openroad,
         env = {
+            "DEFAULT_INPUT_DRIVER_CELL": stdcell_info.default_input_driver_cell,
+            "DEFAULT_OUTPUT_LOAD": stdcell_info.default_output_load,
             "QT_QPA_PLATFORM": ctx.attr.qt_qpa_platform,
             "TCL_LIBRARY": openroad_runfiles_dir + "/tk_tcl/library",
         },


### PR DESCRIPTION
With this change, users can add IO load constraints in their SDC files without knowing specifics of the stdcells provided by the PDK in the `StandardCellInfo`.

I.e.,
```
set_load -pin_load $::env(DEFAULT_OUTPUT_LOAD) [all_outputs]
set_driving_cell -lib_cell $::env(DEFAULT_INPUT_DRIVER_CELL) \
 -input_transition_rise 0.125 -input_transition_fall 0.125 [all_inputs]
```