### PR TITLE
Add *Machine.cc files that are included by Machine.cc.

### DIFF
--- a/dependency_support/org_theopenroadproject/bundled.BUILD.bazel
+++ b/dependency_support/org_theopenroadproject/bundled.BUILD.bazel
@@ -1428,7 +1428,10 @@ cc_library(
     hdrs = glob(
         include = ["src/sta/include/sta/*.hh"],
     ) + [
+        "src/sta/util/MachineApple.cc",
         "src/sta/util/MachineLinux.cc",
+        "src/sta/util/MachineUnknown.cc",
+        "src/sta/util/MachineWin32.cc",
     ],
     copts = [
         "-fexceptions",


### PR DESCRIPTION
OpenRoad includes different `Machine*.cc` files on different platforms, and only Linux was previously included. This change makes all files available to be included.