### PR TITLE
Fix a bug in the pin placement script feature of place_and_route.

### DIFF
--- a/place_and_route/private/place_pins.bzl
+++ b/place_and_route/private/place_pins.bzl
@@ -45,8 +45,8 @@ def place_pins(ctx, open_road_info):
         ]
         tapcell_command = "source {}".format(open_road_configuration.tapcell_tcl.path)
 
-        if ctx.file.pin_placement_script:
-            inputs.append(ctx.file.pin_placement_script)
+    if ctx.file.pin_placement_script:
+        inputs.append(ctx.file.pin_placement_script)
 
     open_road_commands = [
         "source {}".format(ctx.file.pin_placement_script.path) if ctx.file.pin_placement_script else "",


### PR DESCRIPTION
@mikex-oss discovered a bug in which a custom pin placement script is only added to the bazel input flist if there is also a tapcell TCL provided by the open_road_configuration tech library setup.