### PR TITLE
Bump rules_proto pin

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -151,14 +151,6 @@ maybe(
     url = "https://github.com/bazelbuild/rules_proto/releases/download/6.0.2/rules_proto-6.0.2.tar.gz",
 )
 
-load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
-
-rules_proto_dependencies()
-
-load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
-
-rules_proto_toolchains()
-
 maybe(
     http_archive,
     name = "rules_pkg",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -133,13 +133,31 @@ setup_7zip()
 
 maybe(
     http_archive,
-    name = "rules_proto",
-    sha256 = "dc3fb206a2cb3441b485eb1e423165b231235a1ea9b031b4433cf7bc1fa460dd",
-    strip_prefix = "rules_proto-5.3.0-21.7",
-    urls = [
-        "https://github.com/bazelbuild/rules_proto/archive/refs/tags/5.3.0-21.7.tar.gz",
-    ],
+    name = "bazel_features",
+    sha256 = "ba1282c1aa1d1fffdcf994ab32131d7c7551a9bc960fbf05f42d55a1b930cbfb",
+    strip_prefix = "bazel_features-1.15.0",
+    url = "https://github.com/bazel-contrib/bazel_features/releases/download/v1.15.0/bazel_features-v1.15.0.tar.gz",
 )
+
+load("@bazel_features//:deps.bzl", "bazel_features_deps")
+
+bazel_features_deps()
+
+maybe(
+    http_archive,
+    name = "rules_proto",
+    sha256 = "6fb6767d1bef535310547e03247f7518b03487740c11b6c6adb7952033fe1295",
+    strip_prefix = "rules_proto-6.0.2",
+    url = "https://github.com/bazelbuild/rules_proto/releases/download/6.0.2/rules_proto-6.0.2.tar.gz",
+)
+
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
+
+rules_proto_dependencies()
+
+load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
+
+rules_proto_toolchains()
 
 maybe(
     http_archive,

--- a/init.bzl
+++ b/init.bzl
@@ -19,6 +19,8 @@ load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 load("@rules_bison//bison:bison.bzl", "bison_register_toolchains")
 load("@rules_flex//flex:flex.bzl", "flex_register_toolchains")
 load("@rules_m4//m4:m4.bzl", "m4_register_toolchains")
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
+load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
 load("//dependency_support:requirements.bzl", install_pip_deps = "install_deps")
 load("//dependency_support/boost:init_boost.bzl", "init_boost")
 
@@ -45,6 +47,10 @@ def init(python_interpreter = None, python_interpreter_target = None):
         Python toolchain. `python_interpreter_target` takes precedence over
         `python_interpreter` if both are set.
     """
+
+    rules_proto_dependencies()
+    rules_proto_toolchains()
+
     install_deps_kwargs = {}
     if python_interpreter:
         install_deps_kwargs["python_interpreter"] = python_interpreter

--- a/init.bzl
+++ b/init.bzl
@@ -19,11 +19,6 @@ load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 load("@rules_bison//bison:bison.bzl", "bison_register_toolchains")
 load("@rules_flex//flex:flex.bzl", "flex_register_toolchains")
 load("@rules_m4//m4:m4.bzl", "m4_register_toolchains")
-load(
-    "@rules_proto//proto:repositories.bzl",
-    "rules_proto_dependencies",
-    "rules_proto_toolchains",
-)
 load("//dependency_support:requirements.bzl", install_pip_deps = "install_deps")
 load("//dependency_support/boost:init_boost.bzl", "init_boost")
 
@@ -50,9 +45,6 @@ def init(python_interpreter = None, python_interpreter_target = None):
         Python toolchain. `python_interpreter_target` takes precedence over
         `python_interpreter` if both are set.
     """
-    rules_proto_dependencies()
-    rules_proto_toolchains()
-
     install_deps_kwargs = {}
     if python_interpreter:
         install_deps_kwargs["python_interpreter"] = python_interpreter


### PR DESCRIPTION
In [rules_proto v6.0.0](https://github.com/bazelbuild/rules_proto/releases/tag/6.0.0) a breaking change was introduced that moved a public facing macro. This change updates the version of this repository and accounts for the breaking change.