### PR TITLE
Adds ability to use standard cells in user provided RTL

### DIFF
--- a/synthesis/build_defs.bzl
+++ b/synthesis/build_defs.bzl
@@ -140,6 +140,8 @@ def _synthesize_design_impl(ctx):
     if ctx.attr.verilog_defines:
         for define in ctx.attr.verilog_defines:
             args.add(define)
+
+    standard_cell_black_box = ctx.actions.declare_file("{}_stdcells_blackbox.v".format(ctx.attr.name))
     script_env_files = {
         "ABC_SCRIPT": abc_script,
         "ADDITIONAL_LIBERTIES": additional_liberty_files,
@@ -150,6 +152,7 @@ def _synthesize_design_impl(ctx):
         "OUTPUT": output_file,
         "TOP": ctx.attr.top_module,
         "UHDM_FLIST": uhdm_flist,
+        "STANDARD_CELL_BLACK_BOX": standard_cell_black_box,
     }
 
     if ctx.attr.target_clock_period_pico_seconds:

--- a/synthesis/build_defs.bzl
+++ b/synthesis/build_defs.bzl
@@ -184,7 +184,7 @@ def _synthesize_design_impl(ctx):
             env[k] = v
 
     ctx.actions.run(
-        outputs = [output_file, log_file],
+        outputs = [output_file, log_file, standard_cell_black_box],
         inputs = inputs,
         arguments = [args],
         executable = ctx.executable.yosys_tool,

--- a/synthesis/build_defs.bzl
+++ b/synthesis/build_defs.bzl
@@ -150,9 +150,9 @@ def _synthesize_design_impl(ctx):
         "FLIST": verilog_flist,
         "LIBERTY": default_liberty_file,
         "OUTPUT": output_file,
+        "STANDARD_CELL_BLACK_BOX": standard_cell_black_box,
         "TOP": ctx.attr.top_module,
         "UHDM_FLIST": uhdm_flist,
-        "STANDARD_CELL_BLACK_BOX": standard_cell_black_box,
     }
 
     if ctx.attr.target_clock_period_pico_seconds:

--- a/synthesis/build_defs.bzl
+++ b/synthesis/build_defs.bzl
@@ -137,6 +137,9 @@ def _synthesize_design_impl(ctx):
         for dont_use_pattern in or_config.do_not_use_cell_list:
             dont_use_args += " -dont_use {} ".format(dont_use_pattern)
 
+    if ctx.attr.verilog_defines:
+        for define in ctx.attr.verilog_defines:
+            args.add(define)
     script_env_files = {
         "ABC_SCRIPT": abc_script,
         "ADDITIONAL_LIBERTIES": additional_liberty_files,
@@ -342,6 +345,9 @@ synthesize_rtl = rule(
         ),
         "top_module": attr.string(
             default = "top",
+        ),
+        "verilog_defines": attr.string_list(
+            doc = "Verilog defines to pass to the synthesis tool.",
         ),
         "yosys_tool": attr.label(
             default = Label("@at_clifford_yosys//:yosys"),

--- a/synthesis/synth.tcl
+++ b/synthesis/synth.tcl
@@ -12,6 +12,16 @@
 
 yosys -import
 
+set all_liberties [split $::env(ADDITIONAL_LIBERTIES) ","]
+lappend all_liberties $::env(LIBERTY)
+
+# create liberty blackbox so cells can be manually created.
+foreach lib $all_liberties {
+  read_liberty -lib -overwrite $lib
+}
+
+write_verilog -blackboxes $::env(STANDARD_CELL_BLACK_BOX)
+
 # read design
 set srcs_flist_path $::env(FLIST)
 set srcs_flist_file [open $srcs_flist_path "r"]

--- a/synthesis/synth.tcl
+++ b/synthesis/synth.tcl
@@ -27,6 +27,7 @@ set srcs_flist_path $::env(FLIST)
 set srcs_flist_file [open $srcs_flist_path "r"]
 set srcs_flist_data [read $srcs_flist_file]
 set srcs [split $srcs_flist_data "\n"]
+set srcs [linsert $srcs 0 $::env(STANDARD_CELL_BLACK_BOX)]
 puts $srcs
 foreach src $srcs {
     # Skip empty lines, including the implict one after the last \n delimiter


### PR DESCRIPTION
This change also includes a new `verilog_defines` parameter to synthesize_rtl which allows users to set defines that will be used when parsing rtl