### PR TITLE
Add path-specific nvp breakdowns to PPA proto.

### DIFF
--- a/synthesis/power_performance_area.proto
+++ b/synthesis/power_performance_area.proto
@@ -165,9 +165,11 @@ message TimingBreakdown {
   // See `setup_wns_ps` and `setup_tns_ps` descriptions for details.
   optional sint32 setup_wns_ps = 1;
   optional sint64 setup_tns_ps = 2;
+  optional int32 num_setup_violations = 5;
   // See `hold_wns_ps` and `hold_tns_ps` descriptions for details.
   optional sint32 hold_wns_ps = 3;
   optional sint64 hold_tns_ps = 4;
+  optional int32 num_hold_violations = 6;
 }
 
 message Power {


### PR DESCRIPTION
The naming of these fields was selected to be consistent with the existing global timing nvp field names. 