### PR TITLE
Fix text protocol buffer: place `estimation_method` at right level.

### DIFF
--- a/place_and_route/private/benchmark.bzl
+++ b/place_and_route/private/benchmark.bzl
@@ -119,8 +119,8 @@ def benchmark(ctx, open_road_info):
                     switching_watts = "$swi_pow",
                     leakage_watts = "$leak_pow",
                     total_watts = "$tot_pow",
-                    estimation_method = "{} probabilistic switching fraction".format(ctx.attr.power_switching_activity),
                 ),
+                estimation_method = "\"{} probabilistic switching fraction\"".format(ctx.attr.power_switching_activity),
             ),
         ),
     )


### PR DESCRIPTION
Make textproto parseable.

According to [the schema](https://github.com/hdl/bazel_rules_hdl/blob/main/synthesis/power_performance_area.proto#L200), the estimation_method is part of the 'Power' message, not a sub-element of the PowerBreakdown message.

Also: estimation_method is a string, so it needs to be quoted.