### PR TITLE
synth: Make synthesize_rtl emit a VerilogInfo provider

### DIFF
--- a/synthesis/build_defs.bzl
+++ b/synthesis/build_defs.bzl
@@ -221,7 +221,7 @@ def _synthesize_design_impl(ctx):
                 data = [],
                 deps = [],
                 tags = [],
-            )]
+            )],
         ),
     ]
 

--- a/synthesis/build_defs.bzl
+++ b/synthesis/build_defs.bzl
@@ -15,7 +15,7 @@
 """Rules for synthesizing (System)Verilog code."""
 
 load("@rules_hdl//pdk:build_defs.bzl", "StandardCellInfo")
-load("//verilog:defs.bzl", "VerilogInfo")
+load("//verilog:defs.bzl", "VerilogInfo", "make_dag_entry", "make_verilog_info")
 
 # There are no rules to generate this provider, but it does provide the mechansim to build
 # rules based on surelog in the open source world.
@@ -212,6 +212,16 @@ def _synthesize_design_impl(ctx):
             inputs = inputs,
             verilog_files = verilog_files,
             uhdm_files = uhdm_files,
+        ),
+        make_verilog_info(
+            new_entries = [make_dag_entry(
+                label = ctx.label,
+                srcs = [output_file],
+                hdrs = [],
+                data = [],
+                deps = [],
+                tags = [],
+            )]
         ),
     ]
 

--- a/verilog/defs.bzl
+++ b/verilog/defs.bzl
@@ -3,9 +3,9 @@
 load(
     ":providers.bzl",
     _VerilogInfo = "VerilogInfo",
-    _verilog_library = "verilog_library",
     _make_dag_entry = "make_dag_entry",
     _make_verilog_info = "make_verilog_info",
+    _verilog_library = "verilog_library",
 )
 
 VerilogInfo = _VerilogInfo

--- a/verilog/defs.bzl
+++ b/verilog/defs.bzl
@@ -4,7 +4,11 @@ load(
     ":providers.bzl",
     _VerilogInfo = "VerilogInfo",
     _verilog_library = "verilog_library",
+    _make_dag_entry = "make_dag_entry",
+    _make_verilog_info = "make_verilog_info",
 )
 
 VerilogInfo = _VerilogInfo
 verilog_library = _verilog_library
+make_dag_entry = _make_dag_entry
+make_verilog_info = _make_verilog_info

--- a/verilog/providers.bzl
+++ b/verilog/providers.bzl
@@ -24,7 +24,7 @@ VerilogInfo = provider(
     },
 )
 
-def make_dag_entry(srcs, hdrs, data, deps, label):
+def make_dag_entry(srcs, hdrs, data, deps, label, tags):
     """Create a new DAG entry for use in VerilogInfo.
 
     As VerilogInfo should be created via 'merge_verilog_info' (rather than directly),
@@ -42,6 +42,7 @@ def make_dag_entry(srcs, hdrs, data, deps, label):
       data: A list of File that are `data`.
       deps: A list of Label that are deps of this entry.
       label: A Label to use as the name for this entry.
+      tags: A list of str. (Ideally) just the entry tags for later filelist filtering.
     Returns:
       struct with all these fields properly stored.
     """
@@ -50,6 +51,7 @@ def make_dag_entry(srcs, hdrs, data, deps, label):
         hdrs = tuple(hdrs),
         data = tuple(data),
         deps = tuple(deps),
+        tags = tuple(tags),
         label = label,
     )
 
@@ -97,6 +99,7 @@ def _verilog_library_impl(ctx):
             hdrs = ctx.files.hdrs,
             deps = ctx.attr.deps,
             label = ctx.label,
+            tags = [],
         )],
         old_infos = [dep[VerilogInfo] for dep in ctx.attr.deps],
     )


### PR DESCRIPTION
Lets you do gate level sims easier if this rule can be passed as if it were a verilog_library