### PR TITLE
verilog: adds support for include headers

### DIFF
--- a/verilator/defs.bzl
+++ b/verilator/defs.bzl
@@ -104,9 +104,25 @@ def _verilator_cc_library(ctx):
     verilator_toolchain = ctx.toolchains["@rules_hdl//verilator:toolchain_type"]
 
     transitive_srcs = depset([], transitive = [ctx.attr.module[VerilogInfo].dag])
-    all_srcs = [verilog_info_struct.srcs for verilog_info_struct in transitive_srcs.to_list()]
-    all_data = [verilog_info_struct.data for verilog_info_struct in transitive_srcs.to_list()]
+    transitive_srcs_list = transitive_srcs.to_list()
+    all_srcs = [verilog_info_struct.srcs for verilog_info_struct in transitive_srcs_list]
+    all_data = [verilog_info_struct.data for verilog_info_struct in transitive_srcs_list]
     all_files = [src for sub_tuple in (all_srcs + all_data) for src in sub_tuple]
+
+    # Collect all directories named in the `includes` parameter.
+    all_include_tuples = [
+        verilog_info_struct.includes
+            for verilog_info_struct in transitive_srcs_list]
+    all_includes = [
+        include for sub_tuple in all_include_tuples for include in sub_tuple
+    ]
+    all_includes_unique = depset(all_includes).to_list()
+
+    # hdrs should appear in the build sandbox, but *not* in the command line,
+    # so keep them separate, and don't add them to `all_files`.
+    all_hdrs_tuple = [verilog_info_struct.hdrs for verilog_info_struct in transitive_srcs_list]
+    all_hdrs = [hdr for sub_tuple in all_hdrs_tuple for hdr in sub_tuple]
+    all_hdrs_unique = depset(all_hdrs).to_list()
 
     # Filter out .dat files.
     runfiles = []
@@ -127,6 +143,8 @@ def _verilator_cc_library(ctx):
     args.add("--Mdir", verilator_output.path)
     args.add("--top-module", ctx.attr.module_top)
     args.add("--prefix", prefix)
+    # Verilator requires no space between `-I` and the directory name.
+    args.add_all(all_includes_unique, format_each = "-I%s")
     if ctx.attr.trace:
         args.add("--trace")
     for verilog_file in verilog_files:
@@ -139,7 +157,7 @@ def _verilator_cc_library(ctx):
         mnemonic = "VerilatorCompile",
         executable = verilator_toolchain.verilator,
         tools = verilator_toolchain.all_files,
-        inputs = verilog_files,
+        inputs = verilog_files + all_hdrs_unique,
         outputs = [verilator_output],
         progress_message = "[Verilator] Compiling {}".format(ctx.label),
     )


### PR DESCRIPTION
Include headers should not appear in the verilator command line, but should be available in the compilation sandbox.

It seems that verilator rules did not allow `hdrs` files into the sandbox, so this change fixes the issue.

Furthermore, very often core authors use the include directive to read an include file from the directory where the include file is located:

```
`include "file.h"
```

This will not work in bazel, because the expected include path is:

```
`include "directory/where/file/resides/file.h"
```

This rule adds the `includes` parameter to `verilog_library` to allow the user to specify a set of include directories, therefore allowing verilation of included cores.

The `verilator_cc_library` rules is fixed to suport this. It is also fixed to use the `hdrs` files as inputs to the verilation rule.