### PR TITLE
Remove the unused implicit attribute `_cc_toolchains`.

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -34,7 +34,7 @@ steps:
     path: /root/.ssh
 
 # Run the build
-- name: gcr.io/cloud-builders/bazel:6.4.0
+- name: gcr.io/cloud-builders/bazel:7.4.1
   entrypoint: 'bash'
   args:
   - '-c'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -34,7 +34,7 @@ steps:
     path: /root/.ssh
 
 # Run the build
-- name: gcr.io/cloud-builders/bazel:7.4.1
+- name: gcr.io/cloud-builders/bazel:7.3.2
   entrypoint: 'bash'
   args:
   - '-c'

--- a/verilator/defs.bzl
+++ b/verilator/defs.bzl
@@ -198,10 +198,6 @@ verilator_cc_library = rule(
             doc = "Additional command line options to pass to Verilator",
             default = ["-Wall"],
         ),
-        "_cc_toolchain": attr.label(
-            doc = "CC compiler.",
-            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
-        ),
         "_copy_tree": attr.label(
             doc = "A tool for copying a tree of files",
             cfg = "exec",


### PR DESCRIPTION
CC toolchains are gathered from the line:
```
toolchains = use_cc_toolchains(),
```