### PR TITLE
Don't load cc_proto_library from rules_cc: not there anymore.

### DIFF
--- a/pdk/proto/BUILD
+++ b/pdk/proto/BUILD
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_cc//cc:defs.bzl", "cc_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@rules_python//python:proto.bzl", "py_proto_library")
 
@@ -34,7 +33,7 @@ proto_library(
 cc_proto_library(
     name = "pdk_info_cc_proto",
     deps = [":pdk_info_proto"],
-)
+)  # buildifier: disable=native-cc-proto
 
 py_proto_library(
     name = "pdk_info_py_proto",

--- a/synthesis/BUILD.bazel
+++ b/synthesis/BUILD.bazel
@@ -14,7 +14,6 @@
 
 # Synthesis tool package.
 
-load("@rules_cc//cc:defs.bzl", "cc_proto_library")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@rules_python//python:proto.bzl", "py_proto_library")
@@ -48,4 +47,4 @@ py_proto_library(
 cc_proto_library(
     name = "power_performance_area_cc_proto",
     deps = [":power_performance_area_proto"],
-)
+)  # buildifier: disable=native-cc-proto


### PR DESCRIPTION
Since 6.x, the cc_proto_library() is part of default bazel rules https://bazel.build/versions/6.5.0/reference/be/c-cpp

And removed as of 0.1.0 from rules_cc:
https://github.com/bazelbuild/rules_cc/releases/tag/0.1.0

making the load call fail if used in a context with newer rules_cc.