### PR TITLE
Use Posix-compatible way to refer to bash

### DIFF
--- a/dependency_support/com_opencircuitdesign_magic/use_bash.patch
+++ b/dependency_support/com_opencircuitdesign_magic/use_bash.patch
@@ -22,7 +22,7 @@ index 01e4fa5..f587a72 100755
 +++ scripts/makedbh
 @@ -1,189 +1,185 @@
 -#!/bin/csh -f
-+#!/bin/bash
++#!/usr/bin/env bash
  #
 -# makes the "database.h" (1st argument, $1) file from "database.h.in"
 -# (2nd argument, $2), setting various mask operation definitions

--- a/flows/analysis/pipeline_balance.sh
+++ b/flows/analysis/pipeline_balance.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 export CONSTANT_CLOCK_PORT=clk
 export CONSTANT_TOP=$3
 export OUTPUT_NETLIST=`mktemp -p /tmp XXXXXXXX.v`

--- a/flows/analysis/reg2reg_path.sh
+++ b/flows/analysis/reg2reg_path.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 export CONSTANT_CLOCK_PORT=clk
 export CONSTANT_TOP=$3
 export OUTPUT_NETLIST=`mktemp -p /tmp XXXXXXXX.v`

--- a/flows/analysis/run_critical_path.sh
+++ b/flows/analysis/run_critical_path.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 time CONSTANT_CLOCK_PORT=clk CONSTANT_TOP=$3 OUTPUT_NETLIST=`mktemp -p /tmp XXXXXXXX.v`  INPUT_RTL=$2 bazel run //flows/analysis:critical_path_$1

--- a/flows/flows.bzl
+++ b/flows/flows.bzl
@@ -40,7 +40,7 @@ FlowStepInfo = provider(
 )
 
 script_prefix = """
-#!/bin/bash
+#!/usr/bin/env bash
 export RUNFILES="${RUNFILES:-$0.runfiles/rules_hdl}"
 """
 

--- a/synthesis/build_defs.bzl
+++ b/synthesis/build_defs.bzl
@@ -293,7 +293,7 @@ def _synthesize_binary_impl(ctx):
 
     env["OUTPUT"] = "/tmp/{}.v".format(ctx.attr.name)
 
-    script += "#!/bin/bash\n"
+    script += "#!/usr/bin/env bash\n"
 
     for k, v in env.items():
         script += "export {}='{}'\n".format(k, v.short_path if type(v) == "File" else v)
@@ -413,7 +413,7 @@ def _benchmark_synth_impl(ctx):
     ctx.actions.write(
         output = executable_file,
         content = "\n".join([
-            "#!/bin/bash",
+            "#!/usr/bin/env bash",
             "set -e",
             cmd1,
             cmd2,

--- a/toolchains/clang/build.sh
+++ b/toolchains/clang/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/vivado/tests/xilinx_env.sh
+++ b/vivado/tests/xilinx_env.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 export HOME=/tmp
 source /opt/xilinx/Vivado/2021.2/settings64.sh


### PR DESCRIPTION
The hard-coded path /bin/bash might not exist (e.g. on NixOS or BSD), so use a Posix-compatible way to refer to interpreter in scripts, using the idiomatic `/usr/bin/env bash`.