### PR TITLE
Flip `@rules_hdl//verilator/settings:avoid_nondeterministic_outputs`

### DIFF
--- a/verilator/settings/BUILD.bazel
+++ b/verilator/settings/BUILD.bazel
@@ -7,5 +7,5 @@ package(default_visibility = ["//visibility:public"])
 # file.
 bool_flag(
     name = "avoid_nondeterministic_outputs",
-    build_setting_default = False,
+    build_setting_default = True,
 )


### PR DESCRIPTION
A followup from https://github.com/hdl/bazel_rules_hdl/pull/383 now activating the new behavior.