### PR TITLE
Update the verilator settings/BUILD.bazel to include standard intro

### DIFF
--- a/verilator/settings/BUILD.bazel
+++ b/verilator/settings/BUILD.bazel
@@ -1,6 +1,25 @@
-load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+# Copyright 2025 bazel_rules_hdl Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-package(default_visibility = ["//visibility:public"])
+load(":defs.bzl", "verilator_toolchain")
+
+package(
+    default_applicable_licenses = ["//:package_license"],
+    default_visibility = ["//visibility:public"],
+)
+
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 
 # A build flag for deleting files known to be non-deterministic from `VerilatorCompile`
 # actions such as the `__verFiles.dat` file which contains timing data for each generated

--- a/verilator/settings/BUILD.bazel
+++ b/verilator/settings/BUILD.bazel
@@ -12,14 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load(":defs.bzl", "verilator_toolchain")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 
 package(
     default_applicable_licenses = ["//:package_license"],
     default_visibility = ["//visibility:public"],
 )
-
-load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 
 # A build flag for deleting files known to be non-deterministic from `VerilatorCompile`
 # actions such as the `__verFiles.dat` file which contains timing data for each generated


### PR DESCRIPTION
Adds the copyright header & default license