### PR TITLE
Add :gtest where needed.

### DIFF
--- a/verilator/tests/BUILD
+++ b/verilator/tests/BUILD
@@ -39,6 +39,7 @@ cc_test(
     srcs = ["adder_test.cc"],
     deps = [
         ":adder_verilator",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -66,6 +67,7 @@ cc_test(
     ],
     deps = [
         ":load_and_count_verilator",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -110,6 +112,7 @@ cc_test(
     ],
     deps = [
         ":nested_module_2_verilator",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/vivado/tests/BUILD
+++ b/vivado/tests/BUILD
@@ -50,6 +50,7 @@ cc_test(
     srcs = ["johnson_counter_test.cc"],
     deps = [
         ":johnson_counter_verilator",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -134,6 +135,7 @@ cc_test(
     ],
     deps = [
         ":weights_replay_verilator",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )


### PR DESCRIPTION
:gtest_main only implicitly provides the includes, but is only really there for the main(). The headers are provided by :gtest

Fixed using the `bant` build_cleaner

```
source <(bant dwyu ...)
```