### PR TITLE
'path' is not a property of filegroup.

### DIFF
--- a/dependency_support/org_swig/bundled.BUILD.bazel
+++ b/dependency_support/org_swig/bundled.BUILD.bazel
@@ -764,7 +764,6 @@ filegroup(
         "Lib/xml/xml.swg",
     ],
     licenses = ["notice"],  # simple notice license for Lib/
-    path = "Lib",
 )
 
 # find . -name '*.h' -print | awk '!/Examples/' | awk '{gsub(/^.\//, "", $0); printf("\"%s\"\n", $0) }'


### PR DESCRIPTION
https://bazel.build/versions/6.5.0/reference/be/general#filegroup

While this is working in 6.x and 7.x and ignored, in 8.x this results about a complaint about this non-existent property.