### PR TITLE
CI: bump ubuntu version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   buildifier:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       BUILDIFIER_VERSION: v6.3.3
     steps:


### PR DESCRIPTION
This PR bumps Ubuntu version used in CI, as 20.04 is not supported anymore and builds fail with:

```
This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101
```