### PR TITLE
Modify synthesis rule to allow operations preservation

### DIFF
--- a/synthesis/build_defs.bzl
+++ b/synthesis/build_defs.bzl
@@ -109,6 +109,9 @@ def _synthesize_design_impl(ctx):
     inputs.append(default_liberty_file)
     inputs.extend(additional_liberty_files)
 
+    if ctx.file.early_techmap:
+        inputs.append(ctx.file.early_techmap)
+
     yosys_runfiles_dir = ctx.executable.yosys_tool.path + ".runfiles"
 
     log_file = ctx.actions.declare_file("{}_yosys_output.log".format(ctx.attr.name))
@@ -180,6 +183,9 @@ def _synthesize_design_impl(ctx):
         "ABC": yosys_runfiles_dir + "/edu_berkeley_abc/abc",
         "YOSYS_DATDIR": yosys_runfiles_dir + "/at_clifford_yosys/techlibs/",
     }
+
+    if ctx.file.early_techmap:
+        script_env_files["EARLY_TECHMAP"] = ctx.file.early_techmap
 
     for k, v in script_env_files.items():
         if type(v) == "File":
@@ -392,6 +398,11 @@ synthesize_rtl = rule(
             default = Label("@at_clifford_yosys//:yosys"),
             executable = True,
             cfg = "exec",
+        ),
+        "early_techmap": attr.label(
+            allow_single_file = True,
+            mandatory = False,
+            doc = "verilog/system verilog file for early techmap process"
         ),
     },
 )

--- a/synthesis/synth.tcl
+++ b/synthesis/synth.tcl
@@ -9,6 +9,7 @@
 # LIBERTY = liberty file for the target technology library
 # OUTPUT = verilog file for synthesis output
 # STATS_JSON = json file for structured stats output
+# EARLY_TECHMAP = verilog/system verilog file for early techmap process
 
 yosys -import
 
@@ -56,6 +57,11 @@ foreach src $srcs {
 # generic synthesis
 set top $::env(TOP)
 hierarchy -check -top $top
+
+if { [info exists ::env(EARLY_TECHMAP)]} {
+    techmap -map $::env(EARLY_TECHMAP)
+}
+
 # Move proc_mux at the end of `yosys proc` to avoid inferred latches.
 # See https://github.com/YosysHQ/yosys/issues/3456
 # Ideally the bug would be solved in UHDM/Yosys.


### PR DESCRIPTION
This PR allows to specify a techmap file which will be used at the early stage of synthesis to prevent breaking down of operations that user want to keep.