### PR TITLE
Add synthesis rule variable for additional Yosys `synth` pass arguments

### DIFF
--- a/synthesis/build_defs.bzl
+++ b/synthesis/build_defs.bzl
@@ -160,6 +160,7 @@ def _synthesize_design_impl(ctx):
         "LIBERTY": default_liberty_file,
         "OUTPUT": output_file,
         "STANDARD_CELL_BLACK_BOX": standard_cell_black_box,
+        "SYNTH_ADDITIONAL_ARGS": ctx.attr.synth_additional_args,
         "TOP": ctx.attr.top_module,
         "UHDM_FLIST": uhdm_flist,
     }
@@ -384,6 +385,11 @@ synthesize_rtl = rule(
         "standard_cells": attr.label(
             providers = [StandardCellInfo],
             default = "@com_google_skywater_pdk_sky130_fd_sc_hd//:sky130_fd_sc_hd",
+        ),
+        "synth_additional_args": attr.string(
+            mandatory = False,
+            doc = "Additional args for the Yosys synth pass",
+            default = "",
         ),
         "synth_tcl": attr.label(
             default = Label("//synthesis:synth.tcl"),

--- a/synthesis/synth.tcl
+++ b/synthesis/synth.tcl
@@ -10,6 +10,7 @@
 # OUTPUT = verilog file for synthesis output
 # STATS_JSON = json file for structured stats output
 # EARLY_TECHMAP = verilog/system verilog file for early techmap process
+# SYNTH_ADDITIONAL_ARGS = Additional args for the Yosys synth pass
 
 yosys -import
 
@@ -79,7 +80,12 @@ yosys delete {*/t:$print}
 # pass.
 yosys opt_clean -purge
 
-yosys synth -top $top -noshare
+set synth_args "-noshare"
+if { [info exists ::env(SYNTH_ADDITIONAL_ARGS)] && ![string equal $::env(SYNTH_ADDITIONAL_ARGS) ""] } {
+  set synth_args "$synth_args $::env(SYNTH_ADDITIONAL_ARGS)"
+}
+
+yosys synth -top $top {*}$synth_args
 
 # Remove internal only aliases for public nets and then give created instances
 # useful names. At this stage it is all the other synthesizable constructs.


### PR DESCRIPTION
This PR fixes a problem with technology mapping of adders which caused arithmetic operations such as addition or subtraction give incorrect results. It is caused by the `abc` command in the `yosys synth` pass before extracting and mapping fa/ha adders.

Steps to reproduce:

- Prerequisites:

  - [Verilator](https://github.com/verilator/verilator) (tested on commit `4990b441209`)
  - [asap7sc7p5t_28](https://github.com/The-OpenROAD-Project/asap7sc7p5t_28) and path to its base directory as env variable `ASAP7_SOURCES` (tested on commit `f970bd3c32`)
  - `add_tb.sv`, `add.sv` and `BUILD.bazel` design files added as attachments
  - it is assumed that design files will be placed in `add` as `bazel_rules_hdl` subdirectory

- Steps

  - Synthesize the design: 
    
    ```
    bazel build //add:verilog_add_synth
    ```
  
  - Move the synthesized `add` module from the output directory to the design files and run verilation

    ```
    verilator --binary -Wno-TIMESCALEMOD --top-module add_tb add_tb.sv verilog_add_synth_synth_output.v \
        $ASAP7_SOURCES/Verilog/asap7sc7p5t_SEQ_RVT_TT_220101.v \
        $ASAP7_SOURCES/Verilog/asap7sc7p5t_SIMPLE_RVT_TT_201020.v \
        $ASAP7_SOURCES/Verilog/asap7sc7p5t_INVBUF_RVT_TT_201020.v \
        $ASAP7_SOURCES/Verilog/asap7sc7p5t_AO_RVT_TT_201020.v \
        $ASAP7_SOURCES/Verilog/asap7sc7p5t_OA_RVT_TT_201020.v
    ```

  - Simulate the design:

    ```
    ./obj_dir/Vadd_tb
    ```
    
- Output pre-change:

```
 10 +   3 =   0
 10 +   3 =  89
- add_tb.sv:18: Verilog $finish
```

- Output post-change:

```
 10 +   3 =   0
 10 +   3 =  13
- add_tb.sv:18: Verilog $finish
```

Design files:
[add.zip](https://github.com/user-attachments/files/20688871/add.zip)