### PR TITLE
Make sure the Python interpreter can be found.

### DIFF
--- a/dependency_support/com_google_skywater_pdk/build_defs.bzl
+++ b/dependency_support/com_google_skywater_pdk/build_defs.bzl
@@ -54,6 +54,7 @@ def _skywater_corner_impl(ctx):
         inputs = ctx.files.srcs,
         arguments = [args],
         executable = ctx.executable._liberty_tool,
+        use_default_shell_env = True,
     )
 
     return [

--- a/dependency_support/org_theopenroadproject_asap7_pdk_r1p7/asap7.bzl
+++ b/dependency_support/org_theopenroadproject_asap7_pdk_r1p7/asap7.bzl
@@ -247,6 +247,7 @@ def _asap7_cell_library_impl(ctx):
         inputs = default_corner_libraries,
         arguments = [args],
         executable = ctx.executable._combine_liberty,
+        use_default_shell_env = True,
     )
 
     open_road_configuration = None


### PR DESCRIPTION
Some rules use Python from the system but with assumptions that don't work on systems with diferent paths such as NixOS or BSD. Make sure it can be found by using the `use_default_shell_env` option.