### PR TITLE
Add support for suppressing OpenROAD warnings in `place_and_route`

### DIFF
--- a/place_and_route/build_defs.bzl
+++ b/place_and_route/build_defs.bzl
@@ -155,6 +155,9 @@ place_and_route = rule(
             """,
             values = [step[0] for step in PLACE_AND_ROUTE_STEPS],
         ),
+        "suppress_warnings": attr.string_list(
+            doc = "A list of OpenROAD warnings to suppress, e.g., [\"STA-1212\", \"PDR-0020\"].",
+        ),
         "synthesized_rtl": attr.label(
             mandatory = True,
             providers = [SynthesisInfo],

--- a/place_and_route/open_road.bzl
+++ b/place_and_route/open_road.bzl
@@ -211,6 +211,16 @@ def openroad_command(ctx, commands, input_db = None, step_name = None, inputs = 
 
     real_commands = []
 
+    if hasattr(ctx.attr, "suppress_warnings") and ctx.attr.suppress_warnings:
+        for warning in ctx.attr.suppress_warnings:
+            parts = warning.split("-")
+            if len(parts) != 2:
+                fail(
+                    "Invalid format in suppress_warnings: {}. ".format(warning) +
+                    "Expected format: MODULE-NUMBER",
+                )
+            real_commands.append('::utl::suppress_message "{}" "{}"'.format(parts[0], parts[1]))
+
     # Liberty Setup
     stdcell_info = ctx.attr.synthesized_rtl[SynthesisInfo].standard_cell_info
     liberty = stdcell_info.default_corner.liberty


### PR DESCRIPTION
Introduce a `suppress_warnings` attribute to the `place_and_route` rule, allowing users to specify OpenROAD warning codes to be ignored.