### PR TITLE
Add missing bzl_library fix buildifier warnings

### DIFF
--- a/pdk/BUILD
+++ b/pdk/BUILD
@@ -12,9 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
 package(
     default_applicable_licenses = ["//:package_license"],
     default_visibility = ["//visibility:private"],
 )
 
 exports_files(["build_defs.bzl"])
+
+bzl_library(
+    name = "build_defs_bzl",
+    srcs = ["build_defs.bzl"],
+    visibility = ["//visibility:public"],
+)
+
+bzl_library(
+    name = "open_road_configuration_bzl",
+    srcs = ["open_road_configuration.bzl"],
+    visibility = ["//visibility:public"],
+)

--- a/place_and_route/BUILD
+++ b/place_and_route/BUILD
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 # Place and Route tool package.
@@ -25,4 +26,30 @@ pkg_tar(
     srcs = ["@org_theopenroadproject//:openroad"],
     include_runfiles = True,
     strip_prefix = "./",
+)
+
+bzl_library(
+    name = "build_defs_bzl",
+    srcs = ["build_defs.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":open_road_bzl",
+        ":private_bzl",
+        "//pdk:open_road_configuration_bzl",
+        "//synthesis:bzl",
+    ],
+)
+
+bzl_library(
+    name = "open_road_bzl",
+    srcs = ["open_road.bzl"],
+    visibility = ["//visibility:private"],
+    deps = ["//synthesis:bzl"],
+)
+
+bzl_library(
+    name = "private_bzl",
+    srcs = glob(["private/*.bzl"]),
+    visibility = ["//visibility:private"],
+    deps = [":open_road_bzl"],
 )

--- a/synthesis/BUILD.bazel
+++ b/synthesis/BUILD.bazel
@@ -14,6 +14,7 @@
 
 # Synthesis tool package.
 
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@rules_python//python:proto.bzl", "py_proto_library")
@@ -21,6 +22,15 @@ load("@rules_python//python:proto.bzl", "py_proto_library")
 package(
     default_applicable_licenses = ["//:package_license"],
     default_visibility = ["//visibility:public"],
+)
+
+bzl_library(
+    name = "bzl",
+    srcs = [
+        "build_defs.bzl",
+        "defs.bzl",
+    ],
+    visibility = ["//visibility:public"],
 )
 
 exports_files(["synth.tcl"])


### PR DESCRIPTION
This PR adds missing bzl_library targets and establishes proper dependency chains for Starlark files in the pdk, place_and_route, and synthesis packages.