### PR TITLE
fix(verilator): load cc_common explicitly for Bazel 9 compatibility

### DIFF
--- a/verilator/defs.bzl
+++ b/verilator/defs.bzl
@@ -18,6 +18,7 @@
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load("@rules_cc//cc:defs.bzl", "CcInfo")
+load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("//verilog:defs.bzl", "VerilogInfo")
 
 def cc_compile_and_link_static_library(ctx, srcs, hdrs, deps, runfiles, includes = [], defines = []):


### PR DESCRIPTION
Explicit imports are required for Bazel 9 ([see](https://blog.bazel.build/2026/01/20/bazel-9.html#starlarkification-has-landed)).

When bumping the bazel version of a downstream project, I found that without this load, building any verilator-using target on Bazel 9 fails with errors like:

`Error: 'struct' object has no attribute 'configure_features'`

Adding this load is backwards compatible, but will allow bazel 9 users to import without a patch