### PR TITLE
Fix invalid escape (backslash space) in a Python file.

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -750,7 +750,11 @@
               ],
               "strip_prefix": "skywater-pdk-3d7617a1acb92ea883539bcf22a632d6361a5de4",
               "sha256": "49e5b03c26131a03eb038697d396a6ebf14058d78196f5d95c2bbdb0bdc8f32e",
-              "build_file": "@@//dependency_support/com_google_skywater_pdk:bundled.BUILD.bazel"
+              "build_file": "@@//dependency_support/com_google_skywater_pdk:bundled.BUILD.bazel",
+              "patches": [
+                "@@//dependency_support/com_google_skywater_pdk:patches/fix-invalid-escape.patch"
+              ],
+              "patch_strip": 1
             }
           },
           "com_google_skywater_pdk_sky130_fd_sc_hd": {

--- a/dependency_support/com_google_skywater_pdk/com_google_skywater_pdk.bzl
+++ b/dependency_support/com_google_skywater_pdk/com_google_skywater_pdk.bzl
@@ -37,6 +37,8 @@ def com_google_skywater_pdk():
         strip_prefix = "skywater-pdk-3d7617a1acb92ea883539bcf22a632d6361a5de4",
         sha256 = "49e5b03c26131a03eb038697d396a6ebf14058d78196f5d95c2bbdb0bdc8f32e",
         build_file = Label("//dependency_support/com_google_skywater_pdk:bundled.BUILD.bazel"),
+        patches = [Label("//dependency_support/com_google_skywater_pdk:patches/fix-invalid-escape.patch")],
+        patch_strip = 1,
     )
 
     for library_name in CELL_LIBRARIES:

--- a/dependency_support/com_google_skywater_pdk/patches/fix-invalid-escape.patch
+++ b/dependency_support/com_google_skywater_pdk/patches/fix-invalid-escape.patch
@@ -1,0 +1,11 @@
+--- a/scripts/python-skywater-pdk/skywater_pdk/liberty.py
++++ b/scripts/python-skywater-pdk/skywater_pdk/liberty.py
+@@ -473,7 +473,7 @@
+         driver_waveform_name : string; /* Specifies the name of the driver waveform table */
+         index_1 ("float, ... float"); /* Specifies input net transition */
+         index_2 ("float, ... float"); /* Specifies normalized voltage */
+-        values ("float, ... float", \ /* Specifies the time in library units */
++        values ("float, ... float",  /* Specifies the time in library units */
+             ... , \\
+             "float, ... float");
+     }

--- a/dependency_support/pdks_extension.bzl
+++ b/dependency_support/pdks_extension.bzl
@@ -60,6 +60,8 @@ def _pdks_extension_impl(ctx):
         strip_prefix = "skywater-pdk-3d7617a1acb92ea883539bcf22a632d6361a5de4",
         sha256 = "49e5b03c26131a03eb038697d396a6ebf14058d78196f5d95c2bbdb0bdc8f32e",
         build_file = "@rules_hdl//dependency_support/com_google_skywater_pdk:bundled.BUILD.bazel",
+        patches = [Label("//dependency_support/com_google_skywater_pdk:patches/fix-invalid-escape.patch")],
+        patch_strip = 1,
     )
 
     for library_name in CELL_LIBRARIES:


### PR DESCRIPTION
This creates a lot of noisy warning messages when compiling XLS, so let's fix it at the root.
(unfortunately, the skywater github repo is archived, so need to apply as patch here).