### PR TITLE
cocotb: fix build_args parameters passing

### DIFF
--- a/cocotb/cocotb.bzl
+++ b/cocotb/cocotb.bzl
@@ -27,6 +27,9 @@ def _list_to_argstring(data, argname, attr = None, operation = None):
         result += " {}".format(elem)
     return result
 
+def _repeated_argstring(data, argname):
+    return "".join([" --{}={}".format(argname, value) for value in data])
+
 def _dict_to_argstring(data, argname):
     result = " --{}".format(argname) if data else ""
     for key, value in data.items():
@@ -123,7 +126,10 @@ def _get_test_command(ctx, verilog_files, vhdl_files):
 
     includes_args = _list_to_argstring(ctx.attr.includes, "includes")
     testcase_args = _list_to_argstring(ctx.attr.testcase, "testcase")
-    build_args = _list_to_argstring(ctx.attr.build_args, "build_args")
+
+    # Use the --option=value form so argparse does not interpret simulator
+    # flags such as "-Wno-*" as options belonging to this wrapper.
+    build_args = _repeated_argstring(ctx.attr.build_args, "build_args")
     gpi_interfaces_args = _list_to_argstring(ctx.attr.gpi_interfaces, "gpi_interfaces")
     test_args = _list_to_argstring(ctx.attr.test_args, "test_args")
     plus_args = _list_to_argstring(ctx.attr.plus_args, "plus_args")
@@ -162,7 +168,6 @@ def _get_test_command(ctx, verilog_files, vhdl_files):
         seed_args +
         test_module_args
     )
-
     return command
 
 def _cocotb_test_impl(ctx):
@@ -170,7 +175,8 @@ def _cocotb_test_impl(ctx):
     vhdl_files = _collect_vhdl_files(ctx).to_list()
 
     # create test script
-    runner_script = ctx.actions.declare_file("cocotb_runner.sh")
+    runner_script_fname = ctx.label.name + "_cocotb_runner.sh"
+    runner_script = ctx.actions.declare_file(runner_script_fname)
     ctx.actions.write(
         output = runner_script,
         content = _get_test_command(ctx, verilog_files, vhdl_files),

--- a/cocotb/cocotb_wrapper.py
+++ b/cocotb/cocotb_wrapper.py
@@ -101,7 +101,7 @@ def cocotb_argument_parser():
     )
     parser.add_argument(
         "--build_args",
-        nargs="*",
+        action="append",
         default=[],
         help="Extra build arguments for the simulator",
     )

--- a/cocotb/tests/BUILD.bazel
+++ b/cocotb/tests/BUILD.bazel
@@ -28,6 +28,9 @@ verilog_library(
 
 cocotb_test(
     name = "cocotb_counter",
+    build_args = [
+        "-Wall",
+    ],
     defines = {"INIT_CNT": "100"},
     hdl_toplevel = "counter",
     hdl_toplevel_lang = "verilog",


### PR DESCRIPTION
This PR fixes 2 issues with cocotb rules:
* If you passed build arguments through the build_args, e.g. `-Wno-Y`, `--Wno-X`, the script would interpret it as an argument to the python wrapper and fail with an error. Now you can pass the dash-arguments to the simulator correctly.
* I added a second test to check if "-Wall" is correctly passed to verilator, which uncovered that when you try to build multiple tests in the same directory, e.g.
`bazel test //cocotb/tests:*`
you get an error 
`ERROR: file 'cocotb/tests/cocotb_runner.sh' is generated by these conflicting actions:`
so I patched the name of the cocotb_runner.sh script to be unique by appending target name.
