### PR TITLE
Upgrade LLVM toolchain version so it does not depend on libtinfo.so.5

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,7 +9,7 @@ bazel_dep(name = "toolchains_llvm", version = "1.5.0", dev_dependency = True)
 # Configure and register the toolchain.
 llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm", dev_dependency = True)
 llvm.toolchain(
-    llvm_version = "18.1.8",
+    llvm_version = "19.1.7",
 )
 use_repo(llvm, "llvm_toolchain")
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -692,7 +692,7 @@
   "moduleExtensions": {
     "//dependency_support:pdks_extension.bzl%pdks_extension": {
       "general": {
-        "bzlTransitiveDigest": "o+FadBhBCCa2+iFwfix5Hit3NaTazjgvd9BoeFLnzbM=",
+        "bzlTransitiveDigest": "vazBvlmuGhbABsu1hlI3UgVKb6mE6a0QRxum+beR2FY=",
         "usagesDigest": "tZ8UoTI8a5/l1BuCT9OFhu6sDTSdjC/aIHUMK+am4eg=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -2341,7 +2341,7 @@
     "@@toolchains_llvm+//toolchain/extensions:llvm.bzl%llvm": {
       "general": {
         "bzlTransitiveDigest": "i54NfnK6i34XT5yyh16sxeFE2U1s0aiixBtMQYMdAMo=",
-        "usagesDigest": "0xcqQOgAeLeZQn+aDo7D9xdDrwTXCSDB5wn2WrV1Xkc=",
+        "usagesDigest": "htBa/Ekk+MpxRpAGMKkhwk30yZpquYwdow2CVrSvf04=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -2357,7 +2357,7 @@
               "extra_llvm_distributions": {},
               "libclang_rt": {},
               "llvm_mirror": "",
-              "llvm_version": "18.1.8",
+              "llvm_version": "19.1.7",
               "llvm_versions": {},
               "netrc": "",
               "sha256": {},
@@ -2386,7 +2386,7 @@
               "link_flags": {},
               "link_libs": {},
               "llvm_versions": {
-                "": "18.1.8"
+                "": "19.1.7"
               },
               "opt_compile_flags": {},
               "opt_link_flags": {},

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -34,14 +34,19 @@ steps:
     path: /root/.ssh
 
 # Run the build
-- name: gcr.io/cloud-builders/bazel:8.3.1
+- name: marketplace.gcr.io/google/ubuntu2204 # Ubuntu 22.04
   entrypoint: 'bash'
   args:
   - '-c'
   - |
     set -e
+    export DEBIAN_FRONTEND=noninteractive
     apt-get update
-    apt-get install -y libtinfo5 clang
+    apt-get install -y libtinfo5 clang libc6-dev curl git
+    curl -fsSL -o /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v1.29.0/bazelisk-linux-amd64
+    echo "5a408715e932c0250d28bd84555f12edbf70117de42f9181691c736eacc4a992  /usr/local/bin/bazel" | sha256sum -c -
+    chmod +x /usr/local/bin/bazel
+    export USE_BAZEL_VERSION=8.5.0
     BUILD_INVOCATION_ID=$(python3 tools/generate_uuid.py)
     TEST_INVOCATION_ID=$(python3 tools/generate_uuid.py)
     echo STATUS: Reporting logs with build invocation id $$BUILD_INVOCATION_ID and test invocation id $$TEST_INVOCATION_ID to GitHub.


### PR DESCRIPTION
Currently building bazel_rules_hdl locally on Debian Linux gives me an error:

> "libtinfo.so.5: cannot open shared object file: No such file or directory"

This seems to be because modern Linux distributions ship with ncurses 6 (libtinfo.so.6) by default.

This updates LLVM to a more modern version that depends on libtinfo.so.6.

