### PR TITLE
Add local cloudbuild

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -57,6 +57,9 @@ build --incompatible_disallow_empty_glob=true
 ###############################################################################
 ## User flags
 ###############################################################################
+# Rewrite mirrors for more stable downloads.
+common --downloader_config=tools/bazel_downloader.cfg
+
 # Optionally allow users to define custom flags when developing new features.
 # https://bazel.build/configure/best-practices#bazelrc-file
 #

--- a/README.md
+++ b/README.md
@@ -116,3 +116,20 @@ bazel_rules_hdl$ python tools/test_everything.py
 Note: `bazel test ...` does not run the tests in Bazel "remote" repositories,
 and `bazel_rules_hdl` bundles together support for several remote repositories
 -- this script serves as a helper for testing them all explicitly.
+
+### Reproducing Cloud Build locally
+
+Running the Cloud Build configuration locally can help reproduce CI-only issues,
+such as problems with hermetic toolchains or missing system packages. Install
+[the Google Cloud CLI](https://docs.cloud.google.com/sdk/docs/install-sdk) and
+Docker, then install the local Cloud Build component:
+
+```console
+sudo apt-get install google-cloud-cli-cloud-build-local
+```
+
+Then run the configuration in local mode, which does not require CI secrets:
+
+```console
+cloud-build-local --config=cloudbuild.yaml --substitutions=_LOCAL_BUILD=true,_USERNAME=local --dryrun=false .
+```

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -26,6 +26,10 @@ steps:
   args:
   - '-c'
   - |
+    set -e
+    if [[ "${_LOCAL_BUILD}" == "true" ]]; then
+      exit 0
+    fi
     gcloud secrets versions access latest --secret=buildbuddy-cert > /root/.ssh/buildbuddy-cert.pem
     gcloud secrets versions access latest --secret=buildbuddy-key > /root/.ssh/buildbuddy-key.pem
     gcloud secrets versions access latest --secret=github-app-key-cloud-build-status-reporter > /root/.ssh/github-app-key-cloud-build-status-reporter.pem
@@ -47,27 +51,32 @@ steps:
     echo "5a408715e932c0250d28bd84555f12edbf70117de42f9181691c736eacc4a992  /usr/local/bin/bazel" | sha256sum -c -
     chmod +x /usr/local/bin/bazel
     export USE_BAZEL_VERSION=8.5.0
-    BUILD_INVOCATION_ID=$(python3 tools/generate_uuid.py)
-    TEST_INVOCATION_ID=$(python3 tools/generate_uuid.py)
-    echo STATUS: Reporting logs with build invocation id $$BUILD_INVOCATION_ID and test invocation id $$TEST_INVOCATION_ID to GitHub.
-    bazel run --config=ciremotebuild //tools:report_status_to_github -- \
-        --head_sha=${COMMIT_SHA} \
-        --build_invocation_id=$$BUILD_INVOCATION_ID \
-        --test_invocation_id=$$TEST_INVOCATION_ID \
-        --github_app_key_file=/root/.ssh/github-app-key-cloud-build-status-reporter.pem
-    echo STATUS: Reported logs to GitHub.
-    EXTRA_BAZEL_ARGS="--build_metadata=USER=${_USERNAME} \
-        --config=ciremotebuild \
-        --bes_results_url=https://app.buildbuddy.io/invocation/ \
-        --noshow_progress" \
-    EXTRA_BUILD_BAZEL_ARGS="--invocation_id=$$BUILD_INVOCATION_ID" \
-    EXTRA_TEST_BAZEL_ARGS="--invocation_id=$$TEST_INVOCATION_ID \
-                           --test_output=errors" \
-        tools/test_everything.py
+    if [[ "${_LOCAL_BUILD}" == "true" ]]; then
+      tools/test_everything.py
+    else
+      BUILD_INVOCATION_ID=$(python3 tools/generate_uuid.py)
+      TEST_INVOCATION_ID=$(python3 tools/generate_uuid.py)
+      echo STATUS: Reporting logs with build invocation id $$BUILD_INVOCATION_ID and test invocation id $$TEST_INVOCATION_ID to GitHub.
+      bazel run --config=ciremotebuild //tools:report_status_to_github -- \
+          --head_sha=${COMMIT_SHA} \
+          --build_invocation_id=$$BUILD_INVOCATION_ID \
+          --test_invocation_id=$$TEST_INVOCATION_ID \
+          --github_app_key_file=/root/.ssh/github-app-key-cloud-build-status-reporter.pem
+      echo STATUS: Reported logs to GitHub.
+      EXTRA_BAZEL_ARGS="--build_metadata=USER=${_USERNAME} \
+          --config=ciremotebuild \
+          --bes_results_url=https://app.buildbuddy.io/invocation/ \
+          --noshow_progress" \
+      EXTRA_BUILD_BAZEL_ARGS="--invocation_id=$$BUILD_INVOCATION_ID" \
+      EXTRA_TEST_BAZEL_ARGS="--invocation_id=$$TEST_INVOCATION_ID \
+                             --test_output=errors" \
+          tools/test_everything.py
+    fi
   timeout: 10800s
   volumes:
   - name: 'ssh'
     path: /root/.ssh
 
 substitutions:
+  _LOCAL_BUILD: "false"
   _USERNAME: $(commit.author.login)

--- a/dependency_support/pdks_extension.bzl
+++ b/dependency_support/pdks_extension.bzl
@@ -19,6 +19,7 @@ def _pdks_extension_impl(ctx):
             "https://github.com/The-OpenROAD-Project/asap7_pdk_r1p7/archive/1ff7649bbf423207f6f70293dc1cf630cd477365.tar.gz",
         ],
         build_file = "@rules_hdl//dependency_support/org_theopenroadproject_asap7_pdk_r1p7:bundled.BUILD.bazel",
+        type = "tar.gz",
         strip_prefix = "asap7_pdk_r1p7-1ff7649bbf423207f6f70293dc1cf630cd477365",
         sha256 = "b5847f93e55debb49d03ec581e22eb301109ff90c9ad19d35ae1223c70250391",
     )
@@ -28,6 +29,7 @@ def _pdks_extension_impl(ctx):
             "https://github.com/The-OpenROAD-Project/asap7sc6t_26/archive/f572bf760c8bdc853cbafd0742790aba0780089c.tar.gz",
         ],
         build_file = "@rules_hdl//dependency_support/org_theopenroadproject_asap7sc6t_26:bundled.BUILD.bazel",
+        type = "tar.gz",
         strip_prefix = "asap7sc6t_26-f572bf760c8bdc853cbafd0742790aba0780089c",
         sha256 = "4bfe15775eaab3a5cc443d444ef82bf7b9c818ba2ed948ce3d9cc6a4cfa1c36c",
     )
@@ -37,6 +39,7 @@ def _pdks_extension_impl(ctx):
             "https://github.com/The-OpenROAD-Project/asap7sc7p5t_27/archive/900f55ed8bef025f39edcc8b8be5e04a2c55c15a.tar.gz",
         ],
         build_file = "@rules_hdl//dependency_support/org_theopenroadproject_asap7sc7p5t_27:bundled.BUILD.bazel",
+        type = "tar.gz",
         strip_prefix = "asap7sc7p5t_27-900f55ed8bef025f39edcc8b8be5e04a2c55c15a",
         sha256 = "db5531736a34f34e919488468e8ee09ae87495ff8a6188fad375d68c19e10e20",
     )
@@ -46,6 +49,7 @@ def _pdks_extension_impl(ctx):
             "https://github.com/The-OpenROAD-Project/asap7sc7p5t_28/archive/d88477438935a5a388bd6294f682dc405c93c5d2.tar.gz",
         ],
         build_file = "@rules_hdl//dependency_support/org_theopenroadproject_asap7sc7p5t_28:bundled.BUILD.bazel",
+        type = "tar.gz",
         strip_prefix = "asap7sc7p5t_28-d88477438935a5a388bd6294f682dc405c93c5d2",
         sha256 = "7f028a41425b8d736958cae994b3c1722d4bef2c0d28f6bf507b9ac8138ecc41",
     )

--- a/tools/bazel_downloader.cfg
+++ b/tools/bazel_downloader.cfg
@@ -1,0 +1,5 @@
+rewrite ^ftp\.gnu\.org/(?:gnu|pub/gnu)/(.*)$ https://mirrors.kernel.org/gnu/$1
+rewrite ^ftp\.gnu\.org/(?:gnu|pub/gnu)/(.*)$ https://ftp.jaist.ac.jp/pub/GNU/$1
+
+rewrite ^github\.com/The-OpenROAD-Project/([^/]+)/archive/(.*)\.tar\.gz$ https://codeload.github.com/The-OpenROAD-Project/$1/tar.gz/$2
+rewrite ^github\.com/The-OpenROAD-Project/([^/]+)/archive/(.*)\.tar\.gz$ https://github.com/The-OpenROAD-Project/$1/archive/$2.tar.gz


### PR DESCRIPTION
This PR adds:
* option to run the cloudbuild.yaml locally without the secrets
* updates mirrors to more stable downloads - I observed multiple timeouts or fails  when trying to download the ftp or github dependencies